### PR TITLE
feat: 管理者ログイン改善 + 招待機能を追加

### DIFF
--- a/backend/internal/app/auth/accept_invitation_usecase.go
+++ b/backend/internal/app/auth/accept_invitation_usecase.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/auth"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/clock"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/security"
+)
+
+// AcceptInvitationInput represents the input for accepting an invitation
+type AcceptInvitationInput struct {
+	Token       string
+	DisplayName string
+	Password    string
+}
+
+// AcceptInvitationOutput represents the output for accepting an invitation
+type AcceptInvitationOutput struct {
+	AdminID  string `json:"admin_id"`
+	TenantID string `json:"tenant_id"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+}
+
+// AcceptInvitationUsecase handles the accept invitation use case
+type AcceptInvitationUsecase struct {
+	adminRepo      auth.AdminRepository
+	invitationRepo auth.InvitationRepository
+	passwordHasher security.PasswordHasher
+	clock          clock.Clock
+}
+
+// NewAcceptInvitationUsecase creates a new AcceptInvitationUsecase
+func NewAcceptInvitationUsecase(
+	adminRepo auth.AdminRepository,
+	invitationRepo auth.InvitationRepository,
+	passwordHasher security.PasswordHasher,
+	clk clock.Clock,
+) *AcceptInvitationUsecase {
+	return &AcceptInvitationUsecase{
+		adminRepo:      adminRepo,
+		invitationRepo: invitationRepo,
+		passwordHasher: passwordHasher,
+		clock:          clk,
+	}
+}
+
+// Execute executes the accept invitation use case
+func (u *AcceptInvitationUsecase) Execute(ctx context.Context, input AcceptInvitationInput) (*AcceptInvitationOutput, error) {
+	now := u.clock.Now()
+
+	// 1. 招待を取得
+	invitation, err := u.invitationRepo.FindByToken(ctx, input.Token)
+	if err != nil {
+		return nil, ErrInvalidInvitation
+	}
+
+	// 2. 招待を受理できるかチェック（ドメインルール）
+	if err := invitation.CanAccept(now); err != nil {
+		return nil, ErrInvalidInvitation
+	}
+
+	// 3. 既に同じメールアドレスの管理者が存在するかチェック
+	existsAdmin, _ := u.adminRepo.FindByEmailGlobal(ctx, invitation.Email())
+	if existsAdmin != nil {
+		return nil, ErrEmailAlreadyExists
+	}
+
+	// 4. パスワードハッシュ化
+	passwordHash, err := u.passwordHasher.Hash(input.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. Admin作成
+	admin, err := auth.NewAdmin(
+		now,
+		invitation.TenantID(),
+		invitation.Email(),
+		passwordHash,
+		input.DisplayName,
+		invitation.Role(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 6. Adminを保存
+	if err := u.adminRepo.Save(ctx, admin); err != nil {
+		return nil, err
+	}
+
+	// 7. 招待を受理済みに更新
+	if err := invitation.Accept(now); err != nil {
+		return nil, err
+	}
+
+	if err := u.invitationRepo.Save(ctx, invitation); err != nil {
+		return nil, err
+	}
+
+	return &AcceptInvitationOutput{
+		AdminID:  admin.AdminID().String(),
+		TenantID: admin.TenantID().String(),
+		Email:    admin.Email(),
+		Role:     admin.Role().String(),
+	}, nil
+}

--- a/backend/internal/app/auth/dto.go
+++ b/backend/internal/app/auth/dto.go
@@ -4,7 +4,7 @@ import "time"
 
 // LoginInput represents the input for the login use case
 type LoginInput struct {
-	TenantID string // ログイン時のみ Body で受け取る（認証前なのでJWTがない）
+	// TenantID削除: email + password のみでログイン
 	Email    string
 	Password string
 }

--- a/backend/internal/app/auth/errors.go
+++ b/backend/internal/app/auth/errors.go
@@ -9,4 +9,10 @@ var (
 
 	// ErrAccountDisabled is returned when the account is disabled
 	ErrAccountDisabled = errors.New("account is disabled")
+
+	// ErrInvalidInvitation is returned when the invitation is invalid or expired
+	ErrInvalidInvitation = errors.New("invitation is invalid or expired")
+
+	// ErrEmailAlreadyExists is returned when the email already exists
+	ErrEmailAlreadyExists = errors.New("email already exists")
 )

--- a/backend/internal/app/auth/invite_admin_usecase.go
+++ b/backend/internal/app/auth/invite_admin_usecase.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/auth"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/clock"
+)
+
+// InviteAdminInput represents the input for inviting an admin
+type InviteAdminInput struct {
+	InviterAdminID string // JWTから取得
+	Email          string
+	Role           string
+}
+
+// InviteAdminOutput represents the output for inviting an admin
+type InviteAdminOutput struct {
+	InvitationID string    `json:"invitation_id"`
+	Email        string    `json:"email"`
+	Role         string    `json:"role"`
+	Token        string    `json:"token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// InviteAdminUsecase handles the admin invitation use case
+type InviteAdminUsecase struct {
+	adminRepo      auth.AdminRepository
+	invitationRepo auth.InvitationRepository
+	clock          clock.Clock
+}
+
+// NewInviteAdminUsecase creates a new InviteAdminUsecase
+func NewInviteAdminUsecase(
+	adminRepo auth.AdminRepository,
+	invitationRepo auth.InvitationRepository,
+	clk clock.Clock,
+) *InviteAdminUsecase {
+	return &InviteAdminUsecase{
+		adminRepo:      adminRepo,
+		invitationRepo: invitationRepo,
+		clock:          clk,
+	}
+}
+
+// Execute executes the invite admin use case
+func (u *InviteAdminUsecase) Execute(ctx context.Context, input InviteAdminInput) (*InviteAdminOutput, error) {
+	now := u.clock.Now()
+
+	// 1. 招待者のAdmin取得
+	inviterAdminID, err := common.ParseAdminID(input.InviterAdminID)
+	if err != nil {
+		return nil, common.NewValidationError("invalid inviter_admin_id", err)
+	}
+
+	inviterAdmin, err := u.adminRepo.FindByID(ctx, inviterAdminID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Role検証
+	role, err := auth.NewRole(input.Role)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. 既に同じメールアドレスの管理者が存在するかチェック
+	existsAdmin, _ := u.adminRepo.FindByEmailGlobal(ctx, input.Email)
+	if existsAdmin != nil {
+		return nil, common.NewValidationError("admin with this email already exists", nil)
+	}
+
+	// 4. 既に同じメールアドレスの未受理招待が存在するかチェック
+	existsPending, err := u.invitationRepo.ExistsPendingByEmail(ctx, inviterAdmin.TenantID(), input.Email)
+	if err != nil {
+		return nil, err
+	}
+	if existsPending {
+		return nil, common.NewValidationError("pending invitation for this email already exists", nil)
+	}
+
+	// 5. 招待作成（7日間有効）
+	invitation, err := auth.NewInvitation(
+		now,
+		inviterAdmin, // Admin集約を渡す（tenantIDが自動設定される）
+		input.Email,
+		role,
+		7*24*time.Hour, // 7日間
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 6. 招待を保存
+	if err := u.invitationRepo.Save(ctx, invitation); err != nil {
+		return nil, err
+	}
+
+	return &InviteAdminOutput{
+		InvitationID: invitation.InvitationID().String(),
+		Email:        invitation.Email(),
+		Role:         invitation.Role().String(),
+		Token:        invitation.Token(),
+		ExpiresAt:    invitation.ExpiresAt(),
+	}, nil
+}

--- a/backend/internal/domain/auth/invitation.go
+++ b/backend/internal/domain/auth/invitation.go
@@ -1,0 +1,187 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+)
+
+// InvitationID は招待のID
+type InvitationID string
+
+func (id InvitationID) String() string {
+	return string(id)
+}
+
+func (id InvitationID) Validate() error {
+	if id == "" {
+		return common.NewValidationError("invitation_id is required", nil)
+	}
+	return nil
+}
+
+// Invitation は管理者招待を表す集約ルート
+type Invitation struct {
+	invitationID     InvitationID
+	tenantID         common.TenantID    // 招待者のテナントに自動紐付け
+	email            string
+	role             Role
+	token            string
+	createdByAdminID common.AdminID     // 招待者（必須）
+	expiresAt        time.Time
+	acceptedAt       *time.Time
+	createdAt        time.Time
+}
+
+// NewInvitation は新しい招待を作成する
+// DDD原則: 集約ルート生成時にビジネスルールを適用
+func NewInvitation(
+	now time.Time,
+	createdByAdmin *Admin, // ★ Admin集約を受け取る（tenantIDを自動抽出）
+	email string,
+	role Role,
+	expirationDuration time.Duration,
+) (*Invitation, error) {
+	// ビジネスルール: 招待者が有効な管理者である必要がある
+	if !createdByAdmin.IsActive() {
+		return nil, common.NewValidationError("inviter must be active", nil)
+	}
+	if createdByAdmin.IsDeleted() {
+		return nil, common.NewValidationError("inviter must not be deleted", nil)
+	}
+
+	// セキュアなランダムトークン生成（32バイト = 64文字のhex）
+	token, err := generateSecureToken(32)
+	if err != nil {
+		return nil, common.NewValidationError("failed to generate secure token", err)
+	}
+
+	// ★ 招待者のテナントに自動紐付け
+	inv := &Invitation{
+		invitationID:     InvitationID(common.NewULID()),
+		tenantID:         createdByAdmin.TenantID(), // ★ 招待者のテナントを自動設定
+		email:            email,
+		role:             role,
+		token:            token,
+		createdByAdminID: createdByAdmin.AdminID(), // ★ 招待者のIDを記録
+		expiresAt:        now.Add(expirationDuration),
+		createdAt:        now,
+	}
+
+	if err := inv.validate(); err != nil {
+		return nil, err
+	}
+
+	return inv, nil
+}
+
+// ReconstructInvitation は永続化された招待を再構築する
+func ReconstructInvitation(
+	invitationID InvitationID,
+	tenantID common.TenantID,
+	email string,
+	role Role,
+	token string,
+	createdByAdminID common.AdminID,
+	expiresAt time.Time,
+	acceptedAt *time.Time,
+	createdAt time.Time,
+) (*Invitation, error) {
+	inv := &Invitation{
+		invitationID:     invitationID,
+		tenantID:         tenantID,
+		email:            email,
+		role:             role,
+		token:            token,
+		createdByAdminID: createdByAdminID,
+		expiresAt:        expiresAt,
+		acceptedAt:       acceptedAt,
+		createdAt:        createdAt,
+	}
+
+	if err := inv.validate(); err != nil {
+		return nil, err
+	}
+
+	return inv, nil
+}
+
+func (i *Invitation) validate() error {
+	if err := i.invitationID.Validate(); err != nil {
+		return err
+	}
+	if err := i.tenantID.Validate(); err != nil {
+		return err
+	}
+	if err := i.createdByAdminID.Validate(); err != nil {
+		return err
+	}
+	if i.email == "" {
+		return common.NewValidationError("email is required", nil)
+	}
+	if len(i.email) > 255 {
+		return common.NewValidationError("email must be less than 255 characters", nil)
+	}
+	if err := i.role.Validate(); err != nil {
+		return err
+	}
+	if i.token == "" {
+		return common.NewValidationError("token is required", nil)
+	}
+	if i.expiresAt.Before(i.createdAt) {
+		return common.NewValidationError("expires_at must be after created_at", nil)
+	}
+	return nil
+}
+
+// IsExpired は招待が期限切れかどうかを判定する（ドメインルール）
+func (i *Invitation) IsExpired(now time.Time) bool {
+	return now.After(i.expiresAt)
+}
+
+// IsAccepted は招待が既に受理されているかを判定する（ドメインルール）
+func (i *Invitation) IsAccepted() bool {
+	return i.acceptedAt != nil
+}
+
+// CanAccept は招待を受理できるかを判定する（ドメインルール）
+func (i *Invitation) CanAccept(now time.Time) error {
+	if i.IsAccepted() {
+		return common.NewValidationError("invitation already accepted", nil)
+	}
+	if i.IsExpired(now) {
+		return common.NewValidationError("invitation expired", nil)
+	}
+	return nil
+}
+
+// Accept は招待を受理する（状態遷移）
+func (i *Invitation) Accept(now time.Time) error {
+	if err := i.CanAccept(now); err != nil {
+		return err
+	}
+	i.acceptedAt = &now
+	return nil
+}
+
+// Getters（不変性を保つ）
+func (i *Invitation) InvitationID() InvitationID       { return i.invitationID }
+func (i *Invitation) TenantID() common.TenantID        { return i.tenantID }
+func (i *Invitation) Email() string                    { return i.email }
+func (i *Invitation) Role() Role                       { return i.role }
+func (i *Invitation) Token() string                    { return i.token }
+func (i *Invitation) CreatedByAdminID() common.AdminID { return i.createdByAdminID }
+func (i *Invitation) ExpiresAt() time.Time             { return i.expiresAt }
+func (i *Invitation) AcceptedAt() *time.Time           { return i.acceptedAt }
+func (i *Invitation) CreatedAt() time.Time             { return i.createdAt }
+
+// generateSecureToken は暗号学的に安全なランダムトークンを生成する
+func generateSecureToken(length int) (string, error) {
+	bytes := make([]byte, length)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/backend/internal/domain/auth/invitation_repository.go
+++ b/backend/internal/domain/auth/invitation_repository.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+)
+
+// InvitationRepository は招待の永続化を担当する
+type InvitationRepository interface {
+	// Save は招待を保存する（INSERT or UPDATE）
+	Save(ctx context.Context, invitation *Invitation) error
+
+	// FindByToken はトークンで招待を検索する
+	FindByToken(ctx context.Context, token string) (*Invitation, error)
+
+	// FindByTenantID はテナント内の招待一覧を取得する
+	FindByTenantID(ctx context.Context, tenantID common.TenantID) ([]*Invitation, error)
+
+	// ExistsPendingByEmail はテナント内の特定メールアドレスの未受理招待が存在するかチェック
+	ExistsPendingByEmail(ctx context.Context, tenantID common.TenantID, email string) (bool, error)
+
+	// Delete は招待を削除する（物理削除）
+	Delete(ctx context.Context, invitationID InvitationID) error
+}

--- a/backend/internal/domain/auth/repository.go
+++ b/backend/internal/domain/auth/repository.go
@@ -12,12 +12,21 @@ type AdminRepository interface {
 	// Save saves an admin (insert or update)
 	Save(ctx context.Context, admin *Admin) error
 
-	// FindByID finds an admin by ID within a tenant
-	FindByID(ctx context.Context, tenantID common.TenantID, adminID common.AdminID) (*Admin, error)
+	// FindByID finds an admin by ID (global search, no tenant filtering)
+	// 招待機能で使用: テナントをまたいでAdminを検索する必要がある
+	FindByID(ctx context.Context, adminID common.AdminID) (*Admin, error)
+
+	// FindByIDWithTenant finds an admin by ID within a tenant (backward compatible)
+	// 既存コードとの互換性のため、テナントIDとAdminIDで検索するメソッドをリネーム
+	FindByIDWithTenant(ctx context.Context, tenantID common.TenantID, adminID common.AdminID) (*Admin, error)
 
 	// FindByEmail finds an admin by email within a tenant
-	// ログイン時に使用
+	// テナント内検索（後方互換）
 	FindByEmail(ctx context.Context, tenantID common.TenantID, email string) (*Admin, error)
+
+	// FindByEmailGlobal finds an admin by email (global search)
+	// ログイン時に使用: email + password のみでログインするため
+	FindByEmailGlobal(ctx context.Context, email string) (*Admin, error)
 
 	// FindByTenantID finds all admins within a tenant
 	// deleted_at IS NULL のレコードのみ返す

--- a/backend/internal/infra/db/invitation_repository.go
+++ b/backend/internal/infra/db/invitation_repository.go
@@ -1,0 +1,256 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/auth"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// InvitationRepository implements auth.InvitationRepository for PostgreSQL
+type InvitationRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewInvitationRepository creates a new InvitationRepository
+func NewInvitationRepository(db *pgxpool.Pool) *InvitationRepository {
+	return &InvitationRepository{db: db}
+}
+
+// Save saves an invitation (insert or update)
+func (r *InvitationRepository) Save(ctx context.Context, inv *auth.Invitation) error {
+	query := `
+		INSERT INTO invitations (
+			invitation_id, tenant_id, email, role, token,
+			created_by_admin_id, expires_at, accepted_at, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (invitation_id) DO UPDATE SET
+			email = EXCLUDED.email,
+			role = EXCLUDED.role,
+			accepted_at = EXCLUDED.accepted_at
+	`
+
+	_, err := r.db.Exec(ctx, query,
+		inv.InvitationID().String(),
+		inv.TenantID().String(),
+		inv.Email(),
+		inv.Role().String(),
+		inv.Token(),
+		inv.CreatedByAdminID().String(),
+		inv.ExpiresAt(),
+		inv.AcceptedAt(),
+		inv.CreatedAt(),
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to save invitation: %w", err)
+	}
+
+	return nil
+}
+
+// FindByToken finds an invitation by token
+func (r *InvitationRepository) FindByToken(ctx context.Context, token string) (*auth.Invitation, error) {
+	query := `
+		SELECT
+			invitation_id, tenant_id, email, role, token,
+			created_by_admin_id, expires_at, accepted_at, created_at
+		FROM invitations
+		WHERE token = $1
+		LIMIT 1
+	`
+
+	var (
+		invitationIDStr    string
+		tenantIDStr        string
+		email              string
+		roleStr            string
+		tokenStr           string
+		createdByAdminIDStr string
+		expiresAt          time.Time
+		acceptedAt         sql.NullTime
+		createdAt          time.Time
+	)
+
+	err := r.db.QueryRow(ctx, query, token).Scan(
+		&invitationIDStr,
+		&tenantIDStr,
+		&email,
+		&roleStr,
+		&tokenStr,
+		&createdByAdminIDStr,
+		&expiresAt,
+		&acceptedAt,
+		&createdAt,
+	)
+
+	if err == pgx.ErrNoRows {
+		return nil, common.NewNotFoundError("Invitation", token)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find invitation: %w", err)
+	}
+
+	tenantID, err := common.ParseTenantID(tenantIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tenant_id: %w", err)
+	}
+
+	createdByAdminID, err := common.ParseAdminID(createdByAdminIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse created_by_admin_id: %w", err)
+	}
+
+	role, err := auth.NewRole(roleStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse role: %w", err)
+	}
+
+	var acceptedAtPtr *time.Time
+	if acceptedAt.Valid {
+		acceptedAtPtr = &acceptedAt.Time
+	}
+
+	return auth.ReconstructInvitation(
+		auth.InvitationID(invitationIDStr),
+		tenantID,
+		email,
+		role,
+		tokenStr,
+		createdByAdminID,
+		expiresAt,
+		acceptedAtPtr,
+		createdAt,
+	)
+}
+
+// FindByTenantID finds all invitations within a tenant
+func (r *InvitationRepository) FindByTenantID(ctx context.Context, tenantID common.TenantID) ([]*auth.Invitation, error) {
+	query := `
+		SELECT
+			invitation_id, tenant_id, email, role, token,
+			created_by_admin_id, expires_at, accepted_at, created_at
+		FROM invitations
+		WHERE tenant_id = $1
+		ORDER BY created_at DESC
+	`
+
+	rows, err := r.db.Query(ctx, query, tenantID.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to query invitations: %w", err)
+	}
+	defer rows.Close()
+
+	invitations := make([]*auth.Invitation, 0)
+
+	for rows.Next() {
+		var (
+			invitationIDStr    string
+			tenantIDStr        string
+			email              string
+			roleStr            string
+			tokenStr           string
+			createdByAdminIDStr string
+			expiresAt          time.Time
+			acceptedAt         sql.NullTime
+			createdAt          time.Time
+		)
+
+		err := rows.Scan(
+			&invitationIDStr,
+			&tenantIDStr,
+			&email,
+			&roleStr,
+			&tokenStr,
+			&createdByAdminIDStr,
+			&expiresAt,
+			&acceptedAt,
+			&createdAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan invitation: %w", err)
+		}
+
+		parsedTenantID, err := common.ParseTenantID(tenantIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tenant_id: %w", err)
+		}
+
+		createdByAdminID, err := common.ParseAdminID(createdByAdminIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse created_by_admin_id: %w", err)
+		}
+
+		role, err := auth.NewRole(roleStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse role: %w", err)
+		}
+
+		var acceptedAtPtr *time.Time
+		if acceptedAt.Valid {
+			acceptedAtPtr = &acceptedAt.Time
+		}
+
+		inv, err := auth.ReconstructInvitation(
+			auth.InvitationID(invitationIDStr),
+			parsedTenantID,
+			email,
+			role,
+			tokenStr,
+			createdByAdminID,
+			expiresAt,
+			acceptedAtPtr,
+			createdAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reconstruct invitation: %w", err)
+		}
+
+		invitations = append(invitations, inv)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate invitations: %w", err)
+	}
+
+	return invitations, nil
+}
+
+// ExistsPendingByEmail checks if a pending invitation exists for the email
+func (r *InvitationRepository) ExistsPendingByEmail(ctx context.Context, tenantID common.TenantID, email string) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM invitations
+			WHERE tenant_id = $1 AND email = $2 AND accepted_at IS NULL
+		)
+	`
+
+	var exists bool
+	err := r.db.QueryRow(ctx, query, tenantID.String(), email).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check pending invitation: %w", err)
+	}
+
+	return exists, nil
+}
+
+// Delete deletes an invitation (physical delete)
+func (r *InvitationRepository) Delete(ctx context.Context, invitationID auth.InvitationID) error {
+	query := `DELETE FROM invitations WHERE invitation_id = $1`
+
+	result, err := r.db.Exec(ctx, query, invitationID.String())
+	if err != nil {
+		return fmt.Errorf("failed to delete invitation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return common.NewNotFoundError("Invitation", invitationID.String())
+	}
+
+	return nil
+}

--- a/backend/internal/infra/db/migrations/010_modify_admins_global_email.down.sql
+++ b/backend/internal/infra/db/migrations/010_modify_admins_global_email.down.sql
@@ -1,0 +1,11 @@
+-- Migration: 010_modify_admins_global_email (rollback)
+
+-- グローバル一意制約を削除
+DROP INDEX IF EXISTS uq_admins_email_global;
+DROP INDEX IF EXISTS idx_admins_email_lookup;
+
+-- 元のテナント内一意制約に戻す
+ALTER TABLE admins ADD CONSTRAINT uq_admins_tenant_email UNIQUE(tenant_id, email);
+CREATE INDEX idx_admins_email ON admins(tenant_id, email) WHERE deleted_at IS NULL;
+
+COMMENT ON COLUMN admins.email IS 'メールアドレス（ログインID、テナント内一意）';

--- a/backend/internal/infra/db/migrations/010_modify_admins_global_email.up.sql
+++ b/backend/internal/infra/db/migrations/010_modify_admins_global_email.up.sql
@@ -1,0 +1,20 @@
+-- Migration: 010_modify_admins_global_email
+-- Description: メールアドレスをグローバル一意に変更（ログインID化）
+-- 理由: email + password のみでログインできるようにするため
+
+-- 1. 既存の制約を削除
+DROP INDEX IF EXISTS idx_admins_email;
+ALTER TABLE admins DROP CONSTRAINT IF EXISTS uq_admins_tenant_email;
+
+-- 2. メールアドレスをグローバル一意にする（deleted_at IS NULL のみ）
+CREATE UNIQUE INDEX uq_admins_email_global
+    ON admins(email)
+    WHERE deleted_at IS NULL;
+
+-- 3. メールアドレスでの高速検索用インデックス
+CREATE INDEX idx_admins_email_lookup
+    ON admins(email)
+    WHERE deleted_at IS NULL AND is_active = true;
+
+COMMENT ON INDEX uq_admins_email_global IS 'メールアドレスはシステム全体で一意（ログインID）';
+COMMENT ON COLUMN admins.email IS 'メールアドレス（ログインID、システム全体で一意）';

--- a/backend/internal/infra/db/migrations/011_create_invitations.down.sql
+++ b/backend/internal/infra/db/migrations/011_create_invitations.down.sql
@@ -1,0 +1,3 @@
+-- Migration: 011_create_invitations (rollback)
+
+DROP TABLE IF EXISTS invitations;

--- a/backend/internal/infra/db/migrations/011_create_invitations.up.sql
+++ b/backend/internal/infra/db/migrations/011_create_invitations.up.sql
@@ -1,0 +1,39 @@
+-- Migration: 011_create_invitations
+-- Description: 管理者招待テーブルの作成
+
+CREATE TABLE IF NOT EXISTS invitations (
+    invitation_id CHAR(26) PRIMARY KEY,  -- ULID形式
+    tenant_id CHAR(26) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    role VARCHAR(20) NOT NULL, -- 'owner' | 'manager'
+    token VARCHAR(64) NOT NULL UNIQUE, -- セキュアランダムトークン
+    created_by_admin_id CHAR(26) NOT NULL, -- 招待した管理者（必須）
+    expires_at TIMESTAMPTZ NOT NULL,
+    accepted_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_invitations_tenant FOREIGN KEY (tenant_id)
+        REFERENCES tenants(tenant_id) ON DELETE CASCADE,
+    CONSTRAINT fk_invitations_created_by FOREIGN KEY (created_by_admin_id)
+        REFERENCES admins(admin_id) ON DELETE CASCADE,
+    CONSTRAINT invitations_role_check CHECK (role IN ('owner', 'manager'))
+);
+
+-- トークンでの高速検索
+CREATE UNIQUE INDEX idx_invitations_token
+    ON invitations(token);
+
+-- テナント×メールでの招待状況確認（未受理のみ）
+CREATE INDEX idx_invitations_tenant_email
+    ON invitations(tenant_id, email)
+    WHERE accepted_at IS NULL;
+
+-- テナント内の招待一覧検索用
+CREATE INDEX idx_invitations_tenant
+    ON invitations(tenant_id, created_at DESC);
+
+COMMENT ON TABLE invitations IS '管理者招待: 招待者のテナントに自動紐付け';
+COMMENT ON COLUMN invitations.created_by_admin_id IS '招待した管理者（このAdminのtenant_idに自動紐付け）';
+COMMENT ON COLUMN invitations.token IS 'セキュアランダムトークン（64文字hex）';
+COMMENT ON COLUMN invitations.expires_at IS '有効期限（デフォルト7日間）';
+COMMENT ON COLUMN invitations.accepted_at IS '受理日時（NULL=未受理）';

--- a/backend/internal/interface/rest/auth_handler.go
+++ b/backend/internal/interface/rest/auth_handler.go
@@ -22,7 +22,7 @@ func NewAuthHandler(loginUsecase *appAuth.LoginUsecase) *AuthHandler {
 
 // LoginRequest represents the request body for login
 type LoginRequest struct {
-	TenantID string `json:"tenant_id"` // ログイン時のみ Body で受け取る
+	// TenantID削除: email + password のみ
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
@@ -46,10 +46,6 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// バリデーション
-	if req.TenantID == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "tenant_id is required", nil)
-		return
-	}
 	if req.Email == "" {
 		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "email is required", nil)
 		return
@@ -61,7 +57,6 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	// 2. Usecase呼び出し（ビジネスロジックはここにない）
 	output, err := h.loginUsecase.Execute(r.Context(), appAuth.LoginInput{
-		TenantID: req.TenantID,
 		Email:    req.Email,
 		Password: req.Password,
 	})

--- a/backend/internal/interface/rest/invitation_handler.go
+++ b/backend/internal/interface/rest/invitation_handler.go
@@ -1,0 +1,160 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	appAuth "github.com/erenoa/vrc-shift-scheduler/backend/internal/app/auth"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/clock"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/db"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/infra/security"
+)
+
+// InvitationHandler handles invitation-related HTTP requests
+type InvitationHandler struct {
+	inviteAdminUsecase      *appAuth.InviteAdminUsecase
+	acceptInvitationUsecase *appAuth.AcceptInvitationUsecase
+}
+
+// NewInvitationHandler creates a new InvitationHandler
+func NewInvitationHandler(pool *pgxpool.Pool) *InvitationHandler {
+	adminRepo := db.NewAdminRepository(pool)
+	invitationRepo := db.NewInvitationRepository(pool)
+	systemClock := &clock.RealClock{}
+	passwordHasher := security.NewBcryptHasher()
+
+	return &InvitationHandler{
+		inviteAdminUsecase:      appAuth.NewInviteAdminUsecase(adminRepo, invitationRepo, systemClock),
+		acceptInvitationUsecase: appAuth.NewAcceptInvitationUsecase(adminRepo, invitationRepo, passwordHasher, systemClock),
+	}
+}
+
+// InviteAdminRequest represents the request body for inviting an admin
+type InviteAdminRequest struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+// InviteAdminResponse represents the response body for inviting an admin
+type InviteAdminResponse struct {
+	InvitationID string `json:"invitation_id"`
+	Email        string `json:"email"`
+	Role         string `json:"role"`
+	Token        string `json:"token"`
+	ExpiresAt    string `json:"expires_at"`
+}
+
+// InviteAdmin handles POST /api/v1/invitations
+func (h *InvitationHandler) InviteAdmin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// JWTからadmin_idを取得
+	adminID, ok := GetAdminID(ctx)
+	if !ok {
+		RespondError(w, http.StatusUnauthorized, "ERR_UNAUTHORIZED", "admin_id is required", nil)
+		return
+	}
+
+	var req InviteAdminRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "Invalid request body", nil)
+		return
+	}
+
+	if req.Email == "" {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "email is required", nil)
+		return
+	}
+	if req.Role == "" {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "role is required", nil)
+		return
+	}
+
+	output, err := h.inviteAdminUsecase.Execute(ctx, appAuth.InviteAdminInput{
+		InviterAdminID: adminID.String(),
+		Email:          req.Email,
+		Role:           req.Role,
+	})
+	if err != nil {
+		RespondDomainError(w, err)
+		return
+	}
+
+	RespondJSON(w, http.StatusCreated, SuccessResponse{
+		Data: InviteAdminResponse{
+			InvitationID: output.InvitationID,
+			Email:        output.Email,
+			Role:         output.Role,
+			Token:        output.Token,
+			ExpiresAt:    output.ExpiresAt.Format("2006-01-02T15:04:05Z07:00"),
+		},
+	})
+}
+
+// AcceptInvitationRequest represents the request body for accepting an invitation
+type AcceptInvitationRequest struct {
+	DisplayName string `json:"display_name"`
+	Password    string `json:"password"`
+}
+
+// AcceptInvitationResponse represents the response body for accepting an invitation
+type AcceptInvitationResponse struct {
+	AdminID  string `json:"admin_id"`
+	TenantID string `json:"tenant_id"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+}
+
+// AcceptInvitation handles POST /api/v1/invitations/accept/{token}
+func (h *InvitationHandler) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "token is required", nil)
+		return
+	}
+
+	var req AcceptInvitationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "Invalid request body", nil)
+		return
+	}
+
+	if req.DisplayName == "" {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "display_name is required", nil)
+		return
+	}
+	if req.Password == "" {
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "password is required", nil)
+		return
+	}
+
+	output, err := h.acceptInvitationUsecase.Execute(r.Context(), appAuth.AcceptInvitationInput{
+		Token:       token,
+		DisplayName: req.DisplayName,
+		Password:    req.Password,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, appAuth.ErrInvalidInvitation):
+			RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "Invalid or expired invitation", nil)
+		case errors.Is(err, appAuth.ErrEmailAlreadyExists):
+			RespondError(w, http.StatusConflict, "ERR_CONFLICT", "Email already exists", nil)
+		default:
+			RespondDomainError(w, err)
+		}
+		return
+	}
+
+	RespondJSON(w, http.StatusCreated, SuccessResponse{
+		Data: AcceptInvitationResponse{
+			AdminID:  output.AdminID,
+			TenantID: output.TenantID,
+			Email:    output.Email,
+			Role:     output.Role,
+		},
+	})
+}

--- a/backend/internal/interface/rest/middleware.go
+++ b/backend/internal/interface/rest/middleware.go
@@ -160,3 +160,9 @@ func GetMemberID(ctx context.Context) (common.MemberID, bool) {
 	return memberID, ok
 }
 
+// GetAdminID extracts admin ID from context
+func GetAdminID(ctx context.Context) (common.AdminID, bool) {
+	adminID, ok := ctx.Value(ContextKeyAdminID).(common.AdminID)
+	return adminID, ok
+}
+

--- a/backend/internal/interface/rest/router.go
+++ b/backend/internal/interface/rest/router.go
@@ -35,6 +35,10 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 	loginUsecase := auth.NewLoginUsecase(adminRepo, passwordHasher, jwtManager)
 	authHandler := NewAuthHandler(loginUsecase)
 
+	// 招待受理（認証不要）
+	invitationHandler := NewInvitationHandler(dbPool)
+	r.Post("/api/v1/invitations/accept/{token}", invitationHandler.AcceptInvitation)
+
 	// 認証不要ルート
 	r.Route("/api/v1/auth", func(r chi.Router) {
 		r.Post("/login", authHandler.Login)
@@ -108,6 +112,11 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			r.Post("/{schedule_id}/decide", scheduleHandler.DecideSchedule)
 			r.Post("/{schedule_id}/close", scheduleHandler.CloseSchedule)
 			r.Get("/{schedule_id}/responses", scheduleHandler.GetResponses)
+		})
+
+		// Invitation API（管理者のみ）
+		r.Route("/invitations", func(r chi.Router) {
+			r.Post("/", invitationHandler.InviteAdmin)
 		})
 	})
 

--- a/web-frontend/src/lib/api/authApi.ts
+++ b/web-frontend/src/lib/api/authApi.ts
@@ -4,7 +4,7 @@ import type { ApiResponse } from '../../types/api';
  * ログインリクエスト（管理者認証）
  */
 export interface LoginRequest {
-  tenant_id: string;
+  // tenant_id削除: email + password のみ
   email: string;
   password: string;
 }

--- a/web-frontend/src/pages/AdminLogin.tsx
+++ b/web-frontend/src/pages/AdminLogin.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { login } from '../lib/api/authApi';
 
 export default function AdminLogin() {
-  const [tenantId, setTenantId] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -13,11 +12,6 @@ export default function AdminLogin() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-
-    if (!tenantId.trim()) {
-      setError('テナントIDを入力してください');
-      return;
-    }
 
     if (!email.trim()) {
       setError('メールアドレスを入力してください');
@@ -34,7 +28,6 @@ export default function AdminLogin() {
     try {
       // ログインAPI呼び出し
       const result = await login({
-        tenant_id: tenantId.trim(),
         email: email.trim(),
         password: password,
       });
@@ -80,21 +73,6 @@ export default function AdminLogin() {
 
         <form onSubmit={handleSubmit} className="space-y-5">
           <div>
-            <label htmlFor="tenantId" className="block text-sm font-medium text-gray-200 mb-1.5">
-              テナントID
-            </label>
-            <input
-              type="text"
-              id="tenantId"
-              value={tenantId}
-              onChange={(e) => setTenantId(e.target.value)}
-              placeholder="01KBHMYWYKRV8PK8EVYGF1SHV0"
-              className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
-              disabled={loading}
-            />
-          </div>
-
-          <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-200 mb-1.5">
               メールアドレス
             </label>
@@ -134,7 +112,7 @@ export default function AdminLogin() {
           <button
             type="submit"
             className="w-full py-3 px-4 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-600/50 text-white font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-slate-900"
-            disabled={loading || !tenantId.trim() || !email.trim() || !password}
+            disabled={loading || !email.trim() || !password}
           >
             {loading ? (
               <span className="flex items-center justify-center gap-2">


### PR DESCRIPTION
## 主な変更

### 1. ログイン簡素化 (BREAKING CHANGE)
- ログインから tenant_id を削除（email + password のみ）
- email をグローバル一意に変更（テナント横断検索）
- 後方互換性のため FindByIDWithTenant メソッドを追加

### 2. 管理者招待機能
- 招待トークン生成（64文字セキュアランダム、7日間有効）
- 招待受理API（POST /api/v1/invitations/accept/{token}）
- 招待管理API（POST /api/v1/invitations）

### 3. データベース
- Migration 010: admins.email のグローバル一意制約
- Migration 011: invitations テーブル追加

### 4. DDD実装
- Domain層: Invitation集約、Repository IF
- Application層: InviteAdminUsecase、AcceptInvitationUsecase
- Infrastructure層: InvitationRepository実装
- Interface層: InvitationHandler、認証ミドルウェア拡張

### 5. フロントエンド
- AdminLogin: テナントID入力欄を削除
- authApi: LoginRequest型からtenant_id削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)