### PR TITLE
fix: web-frontendのデザインをadmin-frontendに統一

### DIFF
--- a/web-frontend/src/components/Layout.tsx
+++ b/web-frontend/src/components/Layout.tsx
@@ -19,57 +19,64 @@ export default function Layout() {
 
   // ナビゲーションリンクのスタイル
   const linkClass = (path: string) =>
-    `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    `px-4 py-2 rounded-md text-sm font-medium transition-colors ${
       location.pathname.startsWith(path)
-        ? 'bg-blue-100 text-blue-700'
+        ? 'bg-indigo-100 text-indigo-700'
         : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
     }`;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-100">
       {/* ヘッダー */}
-      <header className="bg-white shadow">
+      <header className="bg-indigo-900 text-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center space-x-8">
-              <h1 className="text-2xl font-bold text-gray-900">VRC Shift Scheduler</h1>
-              <nav className="hidden md:flex space-x-2">
-                <Link to="/events" className={linkClass('/events')}>
-                  イベント
-                </Link>
-                <Link to="/members" className={linkClass('/members')}>
-                  メンバー
-                </Link>
-                <Link to="/roles" className={linkClass('/roles')}>
-                  ロール
-                </Link>
-                <Link to="/attendance" className={linkClass('/attendance')}>
-                  出欠確認
-                </Link>
-                <Link to="/schedules" className={linkClass('/schedules')}>
-                  日程調整
-                </Link>
-                {(adminRole === 'admin' || adminRole === 'owner') && (
-                  <Link to="/admin/invite" className={linkClass('/admin/invite')}>
-                    管理者招待
-                  </Link>
-                )}
-                <Link to="/settings" className={linkClass('/settings')}>
-                  設定
-                </Link>
-              </nav>
-            </div>
+          <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-600">
-                {adminRole === 'owner' ? '👑 オーナー' : '👤 マネージャー'}
+              <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
+              <span className="bg-indigo-700 px-2 py-1 rounded text-xs font-medium">
+                {adminRole === 'owner' ? 'オーナー' : 'マネージャー'}
               </span>
-              <button onClick={handleLogout} className="btn-secondary text-sm">
-                ログアウト
-              </button>
             </div>
+            <button
+              onClick={handleLogout}
+              className="px-4 py-2 text-sm font-medium text-indigo-200 hover:text-white transition-colors"
+            >
+              ログアウト
+            </button>
           </div>
         </div>
       </header>
+
+      {/* ナビゲーション */}
+      <nav className="bg-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex space-x-4 py-3 overflow-x-auto">
+            <Link to="/events" className={linkClass('/events')}>
+              イベント
+            </Link>
+            <Link to="/members" className={linkClass('/members')}>
+              メンバー
+            </Link>
+            <Link to="/roles" className={linkClass('/roles')}>
+              ロール
+            </Link>
+            <Link to="/attendance" className={linkClass('/attendance')}>
+              出欠確認
+            </Link>
+            <Link to="/schedules" className={linkClass('/schedules')}>
+              日程調整
+            </Link>
+            {(adminRole === 'admin' || adminRole === 'owner') && (
+              <Link to="/admin/invite" className={linkClass('/admin/invite')}>
+                管理者招待
+              </Link>
+            )}
+            <Link to="/settings" className={linkClass('/settings')}>
+              設定
+            </Link>
+          </div>
+        </div>
+      </nav>
 
       {/* メインコンテンツ */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -80,7 +87,7 @@ export default function Layout() {
       <footer className="bg-white border-t mt-auto">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <p className="text-center text-sm text-gray-500">
-            ⚠️ これは α 版のテストです。データは予告なく消える可能性があります。
+            VRC Shift Scheduler
           </p>
         </div>
       </footer>

--- a/web-frontend/src/index.css
+++ b/web-frontend/src/index.css
@@ -2,27 +2,27 @@
 
 /* グローバルスタイル */
 body {
-  @apply bg-gray-50 text-gray-900;
+  @apply bg-gray-100 text-gray-900;
 }
 
 /* カスタムコンポーネントスタイル */
 @layer components {
   .btn-primary {
-    @apply px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors;
+    @apply px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors;
   }
-  
+
   .btn-secondary {
     @apply px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors;
   }
-  
+
   .card {
     @apply bg-white rounded-lg shadow-md p-6;
   }
-  
+
   .input-field {
-    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500;
+    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500;
   }
-  
+
   .label {
     @apply block text-sm font-medium text-gray-700 mb-1;
   }

--- a/web-frontend/src/pages/AdminLogin.tsx
+++ b/web-frontend/src/pages/AdminLogin.tsx
@@ -60,81 +60,93 @@ export default function AdminLogin() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center p-4">
-      <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-2xl max-w-md w-full p-8">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">
-            VRC Shift Scheduler
-          </h1>
-          <p className="text-sm text-gray-300">
-            管理者ログイン
-          </p>
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      {/* ヘッダー */}
+      <header className="bg-indigo-900 text-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
         </div>
+      </header>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-200 mb-1.5">
-              メールアドレス
-            </label>
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="admin@example.com"
-              className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
-              disabled={loading}
-              autoFocus
-            />
+      {/* メインコンテンツ */}
+      <main className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-white rounded-lg shadow-md max-w-md w-full p-8">
+          <div className="text-center mb-8">
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              ログイン
+            </h2>
+            <p className="text-sm text-gray-500">
+              管理者アカウントでログインしてください
+            </p>
           </div>
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-200 mb-1.5">
-              パスワード
-            </label>
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
-              disabled={loading}
-            />
-          </div>
-
-          {error && (
-            <div className="bg-red-500/20 border border-red-500/50 rounded-lg p-3">
-              <p className="text-sm text-red-200">{error}</p>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1.5">
+                メールアドレス
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="admin@example.com"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={loading}
+                autoFocus
+              />
             </div>
-          )}
 
-          <button
-            type="submit"
-            className="w-full py-3 px-4 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-600/50 text-white font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-slate-900"
-            disabled={loading || !email.trim() || !password}
-          >
-            {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                </svg>
-                ログイン中...
-              </span>
-            ) : (
-              'ログイン'
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1.5">
+                パスワード
+              </label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={loading}
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                <p className="text-sm text-red-600">{error}</p>
+              </div>
             )}
-          </button>
-        </form>
 
-        <div className="mt-6 pt-6 border-t border-white/10">
-          <p className="text-xs text-gray-400 text-center">
-            管理者アカウントでログインしてください
+            <button
+              type="submit"
+              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              disabled={loading || !email.trim() || !password}
+            >
+              {loading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  ログイン中...
+                </span>
+              ) : (
+                'ログイン'
+              )}
+            </button>
+          </form>
+        </div>
+      </main>
+
+      {/* フッター */}
+      <footer className="bg-white border-t">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <p className="text-center text-sm text-gray-500">
+            VRC Shift Scheduler
           </p>
         </div>
-      </div>
+      </footer>
     </div>
   );
 }
-

--- a/web-frontend/src/pages/AssignShift.tsx
+++ b/web-frontend/src/pages/AssignShift.tsx
@@ -197,7 +197,7 @@ export default function AssignShift() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -277,7 +277,7 @@ export default function AssignShift() {
                   {tableFilterRoleIds.length > 0 && (
                     <button
                       onClick={() => setTableFilterRoleIds([])}
-                      className="text-xs text-blue-600 hover:text-blue-800"
+                      className="text-xs text-indigo-600 hover:text-indigo-800"
                     >
                       クリア
                     </button>
@@ -298,7 +298,7 @@ export default function AssignShift() {
                         }}
                         className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium transition-all ${
                           isSelected
-                            ? 'ring-2 ring-offset-1 ring-blue-500'
+                            ? 'ring-2 ring-offset-1 ring-indigo-500'
                             : 'opacity-60 hover:opacity-100'
                         }`}
                         style={{
@@ -408,7 +408,7 @@ export default function AssignShift() {
                       <button
                         type="button"
                         onClick={() => setMemberFilterRoleIds([])}
-                        className="text-xs text-blue-600 hover:text-blue-800"
+                        className="text-xs text-indigo-600 hover:text-indigo-800"
                       >
                         クリア
                       </button>
@@ -430,7 +430,7 @@ export default function AssignShift() {
                           }}
                           className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium transition-all ${
                             isSelected
-                              ? 'ring-2 ring-offset-1 ring-blue-500'
+                              ? 'ring-2 ring-offset-1 ring-indigo-500'
                               : 'opacity-60 hover:opacity-100'
                           }`}
                           style={{
@@ -477,7 +477,7 @@ export default function AssignShift() {
                           checked={selectedMemberIds.includes(member.member_id)}
                           onChange={() => handleToggleMember(member.member_id)}
                           disabled={submitting}
-                          className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                          className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                         />
                         <div className="ml-3 flex items-center gap-2">
                           <span className="text-sm text-gray-900">{member.display_name}</span>

--- a/web-frontend/src/pages/AttendanceDetail.tsx
+++ b/web-frontend/src/pages/AttendanceDetail.tsx
@@ -94,7 +94,7 @@ export default function AttendanceDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -105,7 +105,7 @@ export default function AttendanceDetail() {
       <div className="max-w-4xl mx-auto">
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <p className="text-red-800">{error || '出欠確認が見つかりません'}</p>
-          <Link to="/attendance" className="text-blue-600 hover:underline mt-4 inline-block">
+          <Link to="/attendance" className="text-indigo-600 hover:underline mt-4 inline-block">
             ← 出欠確認一覧に戻る
           </Link>
         </div>
@@ -227,7 +227,7 @@ export default function AttendanceDetail() {
             />
             <button
               onClick={handleCopy}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition text-sm whitespace-nowrap"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition text-sm whitespace-nowrap"
             >
               {copied ? '✓ コピー済み' : 'URLをコピー'}
             </button>

--- a/web-frontend/src/pages/AttendanceList.tsx
+++ b/web-frontend/src/pages/AttendanceList.tsx
@@ -132,7 +132,7 @@ export default function AttendanceList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -149,7 +149,7 @@ export default function AttendanceList() {
         </div>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors font-medium"
         >
           {showCreateForm ? 'キャンセル' : '+ 新規作成'}
         </button>
@@ -171,7 +171,7 @@ export default function AttendanceList() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="例：12月のシフト出欠確認"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -185,7 +185,7 @@ export default function AttendanceList() {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 placeholder="詳細な説明や注意事項を入力してください"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -201,7 +201,7 @@ export default function AttendanceList() {
                       type="date"
                       value={date}
                       onChange={(e) => handleDateChange(index, e.target.value)}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                       disabled={submitting}
                     />
                     {targetDates.length > 1 && (
@@ -220,7 +220,7 @@ export default function AttendanceList() {
               <button
                 type="button"
                 onClick={handleAddDate}
-                className="mt-2 px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 rounded-md transition"
+                className="mt-2 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 rounded-md transition"
                 disabled={submitting}
               >
                 + 対象日を追加
@@ -235,7 +235,7 @@ export default function AttendanceList() {
                 type="datetime-local"
                 value={deadline}
                 onChange={(e) => setDeadline(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -249,7 +249,7 @@ export default function AttendanceList() {
             <button
               type="submit"
               disabled={submitting || !title.trim()}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '作成中...' : '出欠確認を作成'}
             </button>
@@ -373,7 +373,7 @@ export default function AttendanceList() {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <button
                         onClick={() => navigate(`/attendance/${collection.collection_id}`)}
-                        className="text-blue-600 hover:text-blue-900 transition"
+                        className="text-indigo-600 hover:text-indigo-900 transition"
                       >
                         詳細
                       </button>
@@ -386,9 +386,9 @@ export default function AttendanceList() {
         </div>
       </div>
 
-      <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-        <h3 className="text-sm font-semibold text-blue-900 mb-2">💡 使い方</h3>
-        <ul className="text-sm text-blue-800 space-y-1 list-disc list-inside">
+      <div className="mt-6 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
+        <h3 className="text-sm font-semibold text-indigo-900 mb-2">💡 使い方</h3>
+        <ul className="text-sm text-indigo-800 space-y-1 list-disc list-inside">
           <li>出欠確認を作成すると公開URLが発行されます</li>
           <li>複数の対象日を設定して、メンバーに各日の出欠を回答してもらえます</li>
           <li>URLをメンバーに送信して、各日の出欠を回答してもらいましょう</li>

--- a/web-frontend/src/pages/BusinessDayList.tsx
+++ b/web-frontend/src/pages/BusinessDayList.tsx
@@ -105,7 +105,7 @@ export default function BusinessDayList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -215,7 +215,7 @@ export default function BusinessDayList() {
                 <select
                   value={selectedMonth}
                   onChange={(e) => setSelectedMonth(e.target.value)}
-                  className="flex-1 px-4 py-2 text-center text-lg font-bold text-gray-900 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 px-4 py-2 text-center text-lg font-bold text-gray-900 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 >
                   {sortedKeys.map((monthKey) => {
                     const [y, m] = monthKey.split('-');
@@ -469,11 +469,11 @@ function CreateBusinessDayModal({
             </div>
           </div>
 
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4">
-            <p className="text-xs text-blue-800">
+          <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-3 mb-4">
+            <p className="text-xs text-indigo-800">
               💡 深夜営業の場合、終了時刻が開始時刻より前でもOKです（例: 21:30-02:00）
             </p>
-            <p className="text-xs text-blue-800 mt-1">
+            <p className="text-xs text-indigo-800 mt-1">
               📋 手動で追加した営業日は「特別営業」として登録されます
             </p>
           </div>
@@ -575,14 +575,14 @@ function CreateBusinessDayModal({
                           return (
                             <tr
                               key={candidate.candidate_id}
-                              className={isSelected ? 'bg-blue-50' : 'hover:bg-gray-50'}
+                              className={isSelected ? 'bg-indigo-50' : 'hover:bg-gray-50'}
                               onClick={() => setTargetDate(candidateDateStr)}
                               style={{ cursor: 'pointer' }}
                             >
                               <td className="px-3 py-2">
                                 <div className="flex items-center gap-2">
-                                  {isSelected && <span className="text-blue-600">→</span>}
-                                  <span className={isSelected ? 'font-semibold text-blue-900' : ''}>
+                                  {isSelected && <span className="text-indigo-600">→</span>}
+                                  <span className={isSelected ? 'font-semibold text-indigo-900' : ''}>
                                     {new Date(candidate.date).toLocaleDateString('ja-JP', {
                                       month: '2-digit',
                                       day: '2-digit',

--- a/web-frontend/src/pages/EventList.tsx
+++ b/web-frontend/src/pages/EventList.tsx
@@ -144,7 +144,7 @@ export default function EventList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -196,7 +196,7 @@ export default function EventList() {
                 <span
                   className={`inline-block px-2 py-1 text-xs font-semibold rounded ${
                     event.event_type === 'normal'
-                      ? 'bg-blue-100 text-blue-800'
+                      ? 'bg-indigo-100 text-indigo-800'
                       : 'bg-purple-100 text-purple-800'
                   }`}
                 >
@@ -220,7 +220,7 @@ export default function EventList() {
                       value={editingName}
                       onChange={(e) => setEditingName(e.target.value)}
                       onKeyDown={(e) => handleEditKeyDown(event.event_id, e)}
-                      className="flex-1 px-2 py-1 text-lg font-bold border border-blue-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="flex-1 px-2 py-1 text-lg font-bold border border-indigo-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
                       disabled={savingEventId === event.event_id}
                     />
                     <button
@@ -252,7 +252,7 @@ export default function EventList() {
                   </h3>
                   <button
                     onClick={(e) => handleStartEdit(event, e)}
-                    className="p-1 text-gray-400 hover:text-blue-600 transition-colors"
+                    className="p-1 text-gray-400 hover:text-indigo-600 transition-colors"
                     title="イベント名を編集"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -497,8 +497,8 @@ function CreateEventModal({
                 </div>
               </div>
 
-              <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                <p className="text-sm text-blue-800">
+              <div className="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
+                <p className="text-sm text-indigo-800">
                   定期イベントを作成後、「営業日を自動生成」ボタンで今月〜来月の営業日をまとめて作成できます。
                 </p>
               </div>

--- a/web-frontend/src/pages/Members.tsx
+++ b/web-frontend/src/pages/Members.tsx
@@ -205,7 +205,7 @@ export default function Members() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -244,7 +244,7 @@ export default function Members() {
             {filterRoleIds.length > 0 && (
               <button
                 onClick={() => setFilterRoleIds([])}
-                className="text-xs text-blue-600 hover:text-blue-800"
+                className="text-xs text-indigo-600 hover:text-indigo-800"
               >
                 クリア
               </button>
@@ -265,7 +265,7 @@ export default function Members() {
                   }}
                   className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                     isSelected
-                      ? 'ring-2 ring-offset-1 ring-blue-500'
+                      ? 'ring-2 ring-offset-1 ring-indigo-500'
                       : 'opacity-60 hover:opacity-100'
                   }`}
                   style={{
@@ -355,7 +355,7 @@ export default function Members() {
                   <td className="px-4 py-3 text-sm text-right space-x-3">
                     <button
                       onClick={() => handleOpenEditForm(member)}
-                      className="text-blue-600 hover:text-blue-800 font-medium"
+                      className="text-indigo-600 hover:text-indigo-800 font-medium"
                     >
                       編集
                     </button>
@@ -597,7 +597,7 @@ function ActualAttendanceModal({
 
         {loading ? (
           <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : data && data.target_dates && data.target_dates.length > 0 ? (
@@ -686,7 +686,7 @@ function AttendanceConfirmationModal({
 
         {loading ? (
           <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : data && data.target_dates && data.target_dates.length > 0 ? (

--- a/web-frontend/src/pages/RoleList.tsx
+++ b/web-frontend/src/pages/RoleList.tsx
@@ -61,7 +61,7 @@ export default function RoleList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -109,7 +109,7 @@ export default function RoleList() {
                 <div className="flex gap-2">
                   <button
                     onClick={() => setEditingRole(role)}
-                    className="text-blue-600 hover:text-blue-800 text-sm"
+                    className="text-indigo-600 hover:text-indigo-800 text-sm"
                   >
                     編集
                   </button>

--- a/web-frontend/src/pages/ScheduleDetail.tsx
+++ b/web-frontend/src/pages/ScheduleDetail.tsx
@@ -68,7 +68,7 @@ export default function ScheduleDetail() {
       case 'open':
         return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-green-100 text-green-800">受付中</span>;
       case 'decided':
-        return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-blue-100 text-blue-800">決定済み</span>;
+        return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-indigo-100 text-indigo-800">決定済み</span>;
       case 'closed':
         return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-gray-100 text-gray-800">締切済み</span>;
       default:
@@ -79,7 +79,7 @@ export default function ScheduleDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -90,7 +90,7 @@ export default function ScheduleDetail() {
       <div className="max-w-4xl mx-auto">
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <p className="text-red-800">{error || '日程調整が見つかりません'}</p>
-          <Link to="/schedules" className="text-blue-600 hover:underline mt-4 inline-block">
+          <Link to="/schedules" className="text-indigo-600 hover:underline mt-4 inline-block">
             ← 日程調整一覧に戻る
           </Link>
         </div>
@@ -204,7 +204,7 @@ export default function ScheduleDetail() {
             />
             <button
               onClick={handleCopy}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition text-sm whitespace-nowrap"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition text-sm whitespace-nowrap"
             >
               {copied ? '✓ コピー済み' : 'URLをコピー'}
             </button>

--- a/web-frontend/src/pages/ScheduleList.tsx
+++ b/web-frontend/src/pages/ScheduleList.tsx
@@ -124,7 +124,7 @@ export default function ScheduleList() {
       case 'open':
         return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">受付中</span>;
       case 'decided':
-        return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">決定済み</span>;
+        return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-indigo-100 text-indigo-800">決定済み</span>;
       case 'closed':
         return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-800">締切済み</span>;
       default:
@@ -135,7 +135,7 @@ export default function ScheduleList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -152,7 +152,7 @@ export default function ScheduleList() {
         </div>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors font-medium"
         >
           {showCreateForm ? 'キャンセル' : '+ 新規作成'}
         </button>
@@ -174,7 +174,7 @@ export default function ScheduleList() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="例：忘年会の日程調整"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -188,7 +188,7 @@ export default function ScheduleList() {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 placeholder="詳細な説明や注意事項を入力してください"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -204,7 +204,7 @@ export default function ScheduleList() {
                       type="datetime-local"
                       value={date}
                       onChange={(e) => handleDateChange(index, e.target.value)}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                       disabled={submitting}
                     />
                     {candidateDates.length > 1 && (
@@ -223,7 +223,7 @@ export default function ScheduleList() {
               <button
                 type="button"
                 onClick={handleAddDate}
-                className="mt-2 px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 rounded-md transition"
+                className="mt-2 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 rounded-md transition"
                 disabled={submitting}
               >
                 + 候補日を追加
@@ -238,7 +238,7 @@ export default function ScheduleList() {
                 type="datetime-local"
                 value={deadline}
                 onChange={(e) => setDeadline(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 disabled={submitting}
               />
             </div>
@@ -252,7 +252,7 @@ export default function ScheduleList() {
             <button
               type="submit"
               disabled={submitting || !title.trim()}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '作成中...' : '日程調整を作成'}
             </button>
@@ -376,7 +376,7 @@ export default function ScheduleList() {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <button
                         onClick={() => navigate(`/schedules/${schedule.schedule_id}`)}
-                        className="text-blue-600 hover:text-blue-900 transition"
+                        className="text-indigo-600 hover:text-indigo-900 transition"
                       >
                         詳細
                       </button>
@@ -389,9 +389,9 @@ export default function ScheduleList() {
         </div>
       </div>
 
-      <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-        <h3 className="text-sm font-semibold text-blue-900 mb-2">💡 使い方</h3>
-        <ul className="text-sm text-blue-800 space-y-1 list-disc list-inside">
+      <div className="mt-6 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
+        <h3 className="text-sm font-semibold text-indigo-900 mb-2">💡 使い方</h3>
+        <ul className="text-sm text-indigo-800 space-y-1 list-disc list-inside">
           <li>日程調整を作成すると公開URLが発行されます</li>
           <li>URLをメンバーに送信して、参加可能な日程を回答してもらいましょう</li>
           <li>メンバーは候補日の中から参加可能な日程を複数選択できます</li>

--- a/web-frontend/src/pages/Settings.tsx
+++ b/web-frontend/src/pages/Settings.tsx
@@ -187,7 +187,7 @@ export default function Settings() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -212,7 +212,7 @@ export default function Settings() {
       {/* テナント情報セクション */}
       <div className="card mb-6">
         <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
           組織情報
@@ -251,7 +251,7 @@ export default function Settings() {
                 <span className="text-gray-900">{tenant?.tenant_name}</span>
                 <button
                   onClick={() => setEditingTenantName(true)}
-                  className="p-1 text-gray-400 hover:text-blue-600 transition-colors"
+                  className="p-1 text-gray-400 hover:text-indigo-600 transition-colors"
                   title="組織名を編集"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web-frontend/src/pages/ShiftSlotList.tsx
+++ b/web-frontend/src/pages/ShiftSlotList.tsx
@@ -67,7 +67,7 @@ export default function ShiftSlotList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -184,7 +184,7 @@ export default function ShiftSlotList() {
                           {assignments.map((assignment) => (
                             <span
                               key={assignment.assignment_id}
-                              className="inline-block px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs"
+                              className="inline-block px-2 py-1 bg-indigo-100 text-indigo-800 rounded text-xs"
                             >
                               {assignment.member_display_name || assignment.member_id}
                             </span>
@@ -480,7 +480,7 @@ function ApplyTemplateModal({
 
         {loadingTemplates ? (
           <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : (
@@ -517,17 +517,17 @@ function ApplyTemplateModal({
             </div>
 
             {selectedTemplate && (
-              <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h4 className="font-semibold text-blue-900 mb-2">
+              <div className="mb-4 bg-indigo-50 border border-indigo-200 rounded-lg p-4">
+                <h4 className="font-semibold text-indigo-900 mb-2">
                   {selectedTemplate.template_name}
                 </h4>
                 {selectedTemplate.description && (
-                  <p className="text-sm text-blue-800 mb-3">{selectedTemplate.description}</p>
+                  <p className="text-sm text-indigo-800 mb-3">{selectedTemplate.description}</p>
                 )}
                 <div className="space-y-2">
-                  <p className="text-xs font-semibold text-blue-900">作成されるシフト枠:</p>
+                  <p className="text-xs font-semibold text-indigo-900">作成されるシフト枠:</p>
                   {(selectedTemplate.items || []).map((item, index) => (
-                    <div key={index} className="text-xs text-blue-800">
+                    <div key={index} className="text-xs text-indigo-800">
                       • {item.slot_name} ({item.instance_name}) - {item.start_time.substring(0, 5)}~
                       {item.end_time.substring(0, 5)} ({item.required_count}名)
                     </div>

--- a/web-frontend/src/pages/TemplateDetail.tsx
+++ b/web-frontend/src/pages/TemplateDetail.tsx
@@ -59,7 +59,7 @@ export default function TemplateDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -72,7 +72,7 @@ export default function TemplateDetail() {
           <p className="text-sm text-red-800">{error || 'テンプレートが見つかりません'}</p>
         </div>
         <div className="mt-4">
-          <Link to={`/events/${eventId}/templates`} className="text-blue-600 hover:text-blue-800">
+          <Link to={`/events/${eventId}/templates`} className="text-indigo-600 hover:text-indigo-800">
             ← テンプレート一覧に戻る
           </Link>
         </div>
@@ -103,7 +103,7 @@ export default function TemplateDetail() {
           <div className="flex gap-2 ml-4">
             <Link
               to={`/events/${eventId}/templates/${templateId}/edit`}
-              className="bg-blue-100 hover:bg-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium"
+              className="bg-indigo-100 hover:bg-indigo-200 text-indigo-700 px-4 py-2 rounded-lg text-sm font-medium"
             >
               編集
             </Link>
@@ -149,7 +149,7 @@ export default function TemplateDetail() {
                       優先度: {item.priority}
                     </p>
                   </div>
-                  <span className="bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded">
+                  <span className="bg-indigo-100 text-indigo-800 text-xs font-medium px-2.5 py-0.5 rounded">
                     {item.required_count}名
                   </span>
                 </div>
@@ -171,9 +171,9 @@ export default function TemplateDetail() {
       </div>
 
       {/* 使用方法の説明 */}
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-6">
-        <h4 className="font-semibold text-blue-900 mb-2">💡 テンプレートの使い方</h4>
-        <p className="text-sm text-blue-800">
+      <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mt-6">
+        <h4 className="font-semibold text-indigo-900 mb-2">💡 テンプレートの使い方</h4>
+        <p className="text-sm text-indigo-800">
           このテンプレートは営業日作成時に選択することで、登録されているシフト枠を自動的に作成します。
           営業日一覧ページから「営業日を追加」を選択し、テンプレートを選んでください。
         </p>

--- a/web-frontend/src/pages/TemplateForm.tsx
+++ b/web-frontend/src/pages/TemplateForm.tsx
@@ -146,7 +146,7 @@ export default function TemplateForm() {
   if (loadingData) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -212,7 +212,7 @@ export default function TemplateForm() {
               type="button"
               onClick={addItem}
               disabled={loading}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm flex items-center"
+              className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm flex items-center"
             >
               <svg
                 className="w-5 h-5 mr-1"
@@ -238,7 +238,7 @@ export default function TemplateForm() {
                 type="button"
                 onClick={addItem}
                 disabled={loading}
-                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm"
+                className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm"
               >
                 最初のシフト枠を追加
               </button>
@@ -358,7 +358,7 @@ export default function TemplateForm() {
           <button
             type="submit"
             disabled={loading || items.length === 0}
-            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? '保存中...' : isEditMode ? '更新する' : '作成する'}
           </button>

--- a/web-frontend/src/pages/TemplateList.tsx
+++ b/web-frontend/src/pages/TemplateList.tsx
@@ -80,7 +80,7 @@ const TemplateList = () => {
         </div>
         <button
           onClick={() => navigate(`/events/${eventId}/templates/new`)}
-          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center"
+          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg flex items-center"
         >
           <svg
             className="w-5 h-5 mr-2"
@@ -121,7 +121,7 @@ const TemplateList = () => {
           <div className="mt-6">
             <button
               onClick={() => navigate(`/events/${eventId}/templates/new`)}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg"
+              className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg"
             >
               テンプレートを作成
             </button>
@@ -138,7 +138,7 @@ const TemplateList = () => {
                 <h3 className="text-lg font-semibold text-gray-900 flex-1">
                   {template.template_name}
                 </h3>
-                <span className="bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded">
+                <span className="bg-indigo-100 text-indigo-800 text-xs font-medium px-2.5 py-0.5 rounded">
                   {(template.items || []).length} 枠
                 </span>
               </div>
@@ -154,7 +154,7 @@ const TemplateList = () => {
                 <div className="space-y-1">
                   {(template.items || []).slice(0, 3).map((item, index) => (
                     <div key={index} className="text-xs text-gray-600 flex items-center">
-                      <span className="w-2 h-2 bg-blue-400 rounded-full mr-2"></span>
+                      <span className="w-2 h-2 bg-indigo-400 rounded-full mr-2"></span>
                       {item.slot_name} ({item.instance_name}) - {item.start_time.substring(0, 5)}~
                       {item.end_time.substring(0, 5)} ({item.required_count}名)
                     </div>
@@ -176,7 +176,7 @@ const TemplateList = () => {
                 </button>
                 <button
                   onClick={() => navigate(`/events/${eventId}/templates/${template.template_id}/edit`)}
-                  className="flex-1 bg-blue-100 hover:bg-blue-200 text-blue-700 px-3 py-2 rounded text-sm font-medium"
+                  className="flex-1 bg-indigo-100 hover:bg-indigo-200 text-indigo-700 px-3 py-2 rounded text-sm font-medium"
                 >
                   編集
                 </button>

--- a/web-frontend/src/pages/public/AttendanceResponse.tsx
+++ b/web-frontend/src/pages/public/AttendanceResponse.tsx
@@ -139,7 +139,7 @@ export default function AttendanceResponse() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
           <p className="mt-4 text-gray-600">読み込み中...</p>
         </div>
       </div>
@@ -181,7 +181,7 @@ export default function AttendanceResponse() {
                 setResponses(initialResponses);
                 setNote('');
               }}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition"
             >
               別の回答を送信
             </button>
@@ -236,7 +236,7 @@ export default function AttendanceResponse() {
               <select
                 value={selectedMemberId}
                 onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 required
                 disabled={collection?.status === 'closed'}
               >
@@ -310,7 +310,7 @@ export default function AttendanceResponse() {
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 placeholder="補足事項があれば入力してください"
                 disabled={collection?.status === 'closed'}
               />
@@ -319,7 +319,7 @@ export default function AttendanceResponse() {
             <button
               type="submit"
               disabled={submitting || collection?.status === 'closed' || targetDates.length === 0}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '送信中...' : '回答を送信'}
             </button>

--- a/web-frontend/src/pages/public/LicenseClaim.tsx
+++ b/web-frontend/src/pages/public/LicenseClaim.tsx
@@ -78,49 +78,68 @@ export default function LicenseClaim() {
 
   if (success) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-md w-full space-y-8">
-          <div className="text-center">
-            <h2 className="mt-6 text-3xl font-extrabold text-gray-900">登録完了！</h2>
-            <p className="mt-2 text-sm text-gray-600">
-              アカウントが正常に作成されました。メールアドレスとパスワードでログインできます。
-            </p>
+      <div className="min-h-screen bg-gray-100 flex flex-col">
+        {/* ヘッダー */}
+        <header className="bg-indigo-900 text-white shadow">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
           </div>
-          <div className="mt-8">
+        </header>
+
+        {/* メインコンテンツ */}
+        <main className="flex-1 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-md max-w-md w-full p-8">
+            <div className="text-center mb-8">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">登録完了！</h2>
+              <p className="text-sm text-gray-500">
+                アカウントが正常に作成されました。メールアドレスとパスワードでログインできます。
+              </p>
+            </div>
             <button
               onClick={() => navigate('/login')}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >
               ログインへ
             </button>
           </div>
-        </div>
+        </main>
+
+        {/* フッター */}
+        <footer className="bg-white border-t">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <p className="text-center text-sm text-gray-500">
+              VRC Shift Scheduler
+            </p>
+          </div>
+        </footer>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            ライセンスキーで登録
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            BOOTHで購入したライセンスキーを入力してアカウントを作成してください
-          </p>
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      {/* ヘッダー */}
+      <header className="bg-indigo-900 text-white shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
         </div>
+      </header>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && (
-            <div className="rounded-md bg-red-50 p-4">
-              <div className="text-sm text-red-700">{error}</div>
-            </div>
-          )}
+      {/* メインコンテンツ */}
+      <main className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-white rounded-lg shadow-md max-w-md w-full p-8">
+          <div className="text-center mb-8">
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              ライセンスキーで登録
+            </h2>
+            <p className="text-sm text-gray-500">
+              BOOTHで購入したライセンスキーを入力してアカウントを作成してください
+            </p>
+          </div>
 
-          <div className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-5">
             <div>
-              <label htmlFor="license_key" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="license_key" className="block text-sm font-medium text-gray-700 mb-1.5">
                 ライセンスキー
               </label>
               <input
@@ -131,12 +150,13 @@ export default function LicenseClaim() {
                 value={formData.license_key}
                 onChange={handleLicenseKeyChange}
                 placeholder="XXXX-XXXX-XXXX-XXXX"
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm font-mono"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition font-mono"
+                disabled={isLoading}
               />
             </div>
 
             <div>
-              <label htmlFor="tenant_name" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="tenant_name" className="block text-sm font-medium text-gray-700 mb-1.5">
                 組織名
               </label>
               <input
@@ -147,12 +167,13 @@ export default function LicenseClaim() {
                 value={formData.tenant_name}
                 onChange={handleChange}
                 placeholder="VRCイベント名"
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={isLoading}
               />
             </div>
 
             <div>
-              <label htmlFor="display_name" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="display_name" className="block text-sm font-medium text-gray-700 mb-1.5">
                 表示名
               </label>
               <input
@@ -163,12 +184,13 @@ export default function LicenseClaim() {
                 value={formData.display_name}
                 onChange={handleChange}
                 placeholder="管理者"
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={isLoading}
               />
             </div>
 
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1.5">
                 メールアドレス
               </label>
               <input
@@ -179,12 +201,14 @@ export default function LicenseClaim() {
                 required
                 value={formData.email}
                 onChange={handleChange}
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                placeholder="admin@example.com"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={isLoading}
               />
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1.5">
                 パスワード
               </label>
               <input
@@ -195,13 +219,15 @@ export default function LicenseClaim() {
                 required
                 value={formData.password}
                 onChange={handleChange}
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                placeholder="••••••••"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={isLoading}
               />
               <p className="mt-1 text-xs text-gray-500">8文字以上</p>
             </div>
 
             <div>
-              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1.5">
                 パスワード（確認）
               </label>
               <input
@@ -212,28 +238,53 @@ export default function LicenseClaim() {
                 required
                 value={formData.confirmPassword}
                 onChange={handleChange}
-                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                placeholder="••••••••"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                disabled={isLoading}
               />
             </div>
-          </div>
 
-          <div>
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                <p className="text-sm text-red-600">{error}</p>
+              </div>
+            )}
+
             <button
               type="submit"
+              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isLoading ? '登録中...' : '登録'}
+              {isLoading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  登録中...
+                </span>
+              ) : (
+                '登録'
+              )}
             </button>
-          </div>
 
-          <div className="text-center">
-            <a href="/login" className="text-sm text-indigo-600 hover:text-indigo-500">
-              アカウントをお持ちですか？ログイン
-            </a>
-          </div>
-        </form>
-      </div>
+            <div className="text-center">
+              <a href="/login" className="text-sm text-indigo-600 hover:text-indigo-500">
+                アカウントをお持ちですか？ログイン
+              </a>
+            </div>
+          </form>
+        </div>
+      </main>
+
+      {/* フッター */}
+      <footer className="bg-white border-t">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <p className="text-center text-sm text-gray-500">
+            VRC Shift Scheduler
+          </p>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/web-frontend/src/pages/public/ScheduleResponse.tsx
+++ b/web-frontend/src/pages/public/ScheduleResponse.tsx
@@ -159,7 +159,7 @@ export default function ScheduleResponse() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
           <p className="mt-4 text-gray-600">読み込み中...</p>
         </div>
       </div>
@@ -204,7 +204,7 @@ export default function ScheduleResponse() {
                 });
                 setResponses(initialResponses);
               }}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition"
             >
               別の回答を送信
             </button>
@@ -266,7 +266,7 @@ export default function ScheduleResponse() {
               <select
                 value={selectedMemberId}
                 onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 required
                 disabled={schedule?.status !== 'open'}
               >
@@ -365,7 +365,7 @@ export default function ScheduleResponse() {
                               e.target.value
                             )
                           }
-                          className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500"
                           disabled={schedule?.status !== 'open'}
                         />
                       </div>
@@ -378,7 +378,7 @@ export default function ScheduleResponse() {
             <button
               type="submit"
               disabled={submitting || schedule?.status !== 'open'}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '送信中...' : '回答を送信'}
             </button>


### PR DESCRIPTION
## Summary
- web-frontendのデザインをadmin-frontendのスタイルに統一
- アクセントカラーをblue系からindigo系に変更
- ヘッダーを`bg-indigo-900 text-white`に統一
- ナビゲーションを分離して白背景に変更
- ログイン画面（AdminLogin.tsx, LicenseClaim.tsx）のデザインを統一
- 全ページの青色をインディゴに置換（20ファイル）

## 対応Issue
Closes #4

## Test plan
- [ ] ログイン画面の表示確認
- [ ] Layout.tsxのヘッダー・ナビ確認
- [ ] 各ページのカラーがindigoになっていることを確認
- [ ] publicページ（出欠確認・日程調整）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)