### PR TITLE
fix: デバッグ用println文を削除してセキュリティを強化

### DIFF
--- a/backend/internal/interface/rest/schedule_handler.go
+++ b/backend/internal/interface/rest/schedule_handler.go
@@ -575,21 +575,16 @@ func (h *ScheduleHandler) SubmitResponse(w http.ResponseWriter, r *http.Request)
 
 	var req ScheduleSubmitResponseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		println("ERROR: Failed to decode request body:", err.Error())
 		RespondBadRequest(w, "invalid request body")
 		return
 	}
 
-	println("DEBUG: SubmitResponse request - MemberID:", req.MemberID, "ResponseCount:", len(req.Responses))
-
 	if req.MemberID == "" {
-		println("ERROR: member_id is empty")
 		RespondBadRequest(w, "member_id is required")
 		return
 	}
 
 	if len(req.Responses) == 0 {
-		println("ERROR: responses array is empty")
 		RespondBadRequest(w, "at least one response is required")
 		return
 	}


### PR DESCRIPTION
## Summary
- schedule_handler.go から `println()` によるデバッグ出力を削除
- 機密情報（MemberID等）がログに露出するリスクを解消

## Changes
- `backend/internal/interface/rest/schedule_handler.go`: 4箇所の `println()` を削除

## Test plan
- [x] `go build ./cmd/server/` でビルド確認
- [x] 既存機能に影響なし

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)