### PR TITLE
fix: CORS設定を環境変数で制御可能に変更

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,6 +14,10 @@ type Config struct {
 
 	// DatabaseURL is the PostgreSQL connection string
 	DatabaseURL string `envconfig:"DATABASE_URL" required:"true"`
+
+	// AllowedOrigins is a comma-separated list of allowed CORS origins
+	// In production, this should be set to specific domains
+	AllowedOrigins string `envconfig:"ALLOWED_ORIGINS" default:""`
 }
 
 // LoadConfig loads configuration from environment variables

--- a/backend/internal/interface/rest/router.go
+++ b/backend/internal/interface/rest/router.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/erenoa/vrc-shift-scheduler/backend/internal/app/auth"
 	"github.com/erenoa/vrc-shift-scheduler/backend/internal/application/usecase"
@@ -22,7 +23,9 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 	r.Use(middleware.RequestID)
 	r.Use(Recover)
 	r.Use(Logger)
-	r.Use(CORS)
+	// CORS設定: ALLOWED_ORIGINS環境変数で許可オリジンを指定
+	// 未設定の場合は全オリジン許可（開発環境用）
+	r.Use(CORSWithOrigins(os.Getenv("ALLOWED_ORIGINS")))
 
 	// ヘルスチェック（認証不要）
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- CORS で全オリジン許可 (`*`) から環境変数による制御に変更
- 本番環境では `ALLOWED_ORIGINS` に指定したドメインのみ許可
- 開発環境（未設定時）は全オリジン許可

## Changes
- `backend/internal/config/config.go`: AllowedOrigins 設定を追加
- `backend/internal/interface/rest/middleware.go`: CORSWithOrigins ミドルウェアを追加
- `backend/internal/interface/rest/router.go`: 新しい CORS ミドルウェアを使用

## 本番環境での設定
`.env.prod` に以下を設定（既に設定済み）:
```
ALLOWED_ORIGINS=https://vrcshift.com,https://admin.vrcshift.com
```

## Test plan
- [x] `go build ./cmd/server/` でビルド確認
- [x] 既存機能に影響なし

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)