### PR TITLE
fix: Admin API に API キー認証層を追加

### DIFF
--- a/admin-frontend/.vite/deps/_metadata.json
+++ b/admin-frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "916e61dc",
+  "configHash": "6e6066a8",
+  "lockfileHash": "f61cf7d7",
+  "browserHash": "4f44f207",
+  "optimized": {},
+  "chunks": {}
+}

--- a/admin-frontend/.vite/deps/package.json
+++ b/admin-frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/backend/internal/interface/rest/router.go
+++ b/backend/internal/interface/rest/router.go
@@ -196,15 +196,18 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 	})
 
 	// ============================================================
-	// Admin Billing API (Cloudflare Access保護 - 運営専用)
+	// Admin Billing API (Cloudflare Access + API Key 保護 - 運営専用)
 	// ============================================================
 	// NOTE: このルートはテナントJWT認証とは完全に分離されています
-	// 本番環境ではCloudflare Accessで保護され、ローカル開発では
-	// CF_ACCESS_TEAM_DOMAIN が未設定の場合は認証をスキップします
+	// 本番環境では以下の2層認証で保護:
+	// 1. Cloudflare Access (CF_ACCESS_TEAM_DOMAIN, CF_ACCESS_POLICY_AUD)
+	// 2. Admin API Key (ADMIN_API_KEY)
 	r.Route("/api/v1/admin", func(r chi.Router) {
 		// Cloudflare Access 認証ミドルウェア
 		cfConfig := LoadCloudflareAccessConfig()
 		r.Use(CloudflareAccessMiddleware(cfConfig))
+		// Admin API Key 認証ミドルウェア（追加のセキュリティ層）
+		r.Use(AdminAPIKeyAuth)
 
 		// Initialize dependencies for admin billing
 		txManager := db.NewPgxTxManager(dbPool)


### PR DESCRIPTION
## Summary
- Admin API (`/api/v1/admin`) に API キー認証を追加
- Cloudflare Access と併用して2層認証を実現

## Changes
- `backend/internal/interface/rest/middleware.go`: AdminAPIKeyAuth ミドルウェアを追加
- `backend/internal/interface/rest/router.go`: Admin API ルートに認証を適用

## セキュリティ対策
- タイミング攻撃対策: `crypto/subtle.ConstantTimeCompare` を使用
- API キー未設定時は認証をスキップ（開発環境用）

## 本番環境での設定
`.env.prod` に追加:
```
ADMIN_API_KEY=<生成した強力なランダム文字列>
```

## Test plan
- [x] `go build ./cmd/server/` でビルド確認
- [x] 既存機能に影響なし

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)