### PR TITLE
fix: ユーザー向けエラーメッセージを日本語化 (#38)

### DIFF
--- a/backend/internal/application/usecase/license_claim_usecase.go
+++ b/backend/internal/application/usecase/license_claim_usecase.go
@@ -79,12 +79,12 @@ func (uc *LicenseClaimUsecase) Execute(ctx context.Context, input LicenseClaimIn
 
 	// Validate license key format
 	if !billing.ValidateLicenseKeyFormat(input.LicenseKey) {
-		return nil, common.NewValidationError("Invalid license key format", nil)
+		return nil, common.NewValidationError("ライセンスキーの形式が正しくありません", nil)
 	}
 
 	// Validate email
 	if input.Email == "" {
-		return nil, common.NewValidationError("Email is required", nil)
+		return nil, common.NewValidationError("メールアドレスを入力してください", nil)
 	}
 
 	// Validate password complexity
@@ -94,12 +94,12 @@ func (uc *LicenseClaimUsecase) Execute(ctx context.Context, input LicenseClaimIn
 
 	// Validate display name
 	if input.DisplayName == "" {
-		return nil, common.NewValidationError("Display name is required", nil)
+		return nil, common.NewValidationError("表示名を入力してください", nil)
 	}
 
 	// Validate tenant name
 	if input.TenantName == "" {
-		return nil, common.NewValidationError("Tenant name is required", nil)
+		return nil, common.NewValidationError("テナント名を入力してください", nil)
 	}
 
 	// Normalize and hash the license key
@@ -116,16 +116,16 @@ func (uc *LicenseClaimUsecase) Execute(ctx context.Context, input LicenseClaimIn
 			return err
 		}
 		if licenseKey == nil {
-			return common.NewValidationError("Invalid license key", nil)
+			return common.NewValidationError("ライセンスキーが見つかりません", nil)
 		}
 
 		// 2. Verify the key is unused
 		if !licenseKey.IsUnused() {
 			if licenseKey.IsUsed() {
-				return common.NewValidationError("License key has already been used", nil)
+				return common.NewValidationError("このライセンスキーは既に使用されています", nil)
 			}
 			if licenseKey.IsRevoked() {
-				return common.NewValidationError("License key has been revoked", nil)
+				return common.NewValidationError("このライセンスキーは無効化されています", nil)
 			}
 		}
 
@@ -261,11 +261,11 @@ func strPtr(s string) *string {
 // validatePasswordComplexity checks password meets security requirements
 func validatePasswordComplexity(password string) error {
 	if len(password) < 8 {
-		return common.NewValidationError("Password must be at least 8 characters", nil)
+		return common.NewValidationError("パスワードは8文字以上で入力してください", nil)
 	}
 
 	if len(password) > 128 {
-		return common.NewValidationError("Password must be 128 characters or less", nil)
+		return common.NewValidationError("パスワードは128文字以内で入力してください", nil)
 	}
 
 	var hasUpper, hasLower, hasDigit bool
@@ -281,13 +281,13 @@ func validatePasswordComplexity(password string) error {
 	}
 
 	if !hasUpper {
-		return common.NewValidationError("Password must contain at least one uppercase letter", nil)
+		return common.NewValidationError("パスワードには大文字を1文字以上含めてください", nil)
 	}
 	if !hasLower {
-		return common.NewValidationError("Password must contain at least one lowercase letter", nil)
+		return common.NewValidationError("パスワードには小文字を1文字以上含めてください", nil)
 	}
 	if !hasDigit {
-		return common.NewValidationError("Password must contain at least one number", nil)
+		return common.NewValidationError("パスワードには数字を1文字以上含めてください", nil)
 	}
 
 	return nil

--- a/backend/internal/interface/rest/admin_handler.go
+++ b/backend/internal/interface/rest/admin_handler.go
@@ -58,27 +58,27 @@ func (h *AdminHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 	// バリデーション
 	if req.CurrentPassword == "" {
-		RespondBadRequest(w, "current_password is required")
+		RespondBadRequest(w, "現在のパスワードを入力してください")
 		return
 	}
 	if req.NewPassword == "" {
-		RespondBadRequest(w, "new_password is required")
+		RespondBadRequest(w, "新しいパスワードを入力してください")
 		return
 	}
 	if req.ConfirmNewPassword == "" {
-		RespondBadRequest(w, "confirm_new_password is required")
+		RespondBadRequest(w, "確認用パスワードを入力してください")
 		return
 	}
 	if len(req.NewPassword) < 8 {
-		RespondBadRequest(w, "new_password must be at least 8 characters")
+		RespondBadRequest(w, "新しいパスワードは8文字以上で入力してください")
 		return
 	}
 	if req.NewPassword != req.ConfirmNewPassword {
-		RespondBadRequest(w, "new_password and confirm_new_password do not match")
+		RespondBadRequest(w, "新しいパスワードと確認用パスワードが一致しません")
 		return
 	}
 	if req.CurrentPassword == req.NewPassword {
-		RespondBadRequest(w, "new_password must be different from current_password")
+		RespondBadRequest(w, "新しいパスワードは現在のパスワードと異なる必要があります")
 		return
 	}
 
@@ -93,7 +93,7 @@ func (h *AdminHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	if err := h.changePasswordUsecase.Execute(ctx, input); err != nil {
 		// エラーハンドリング
 		if errors.Is(err, appAuth.ErrInvalidCredentials) {
-			RespondError(w, http.StatusUnauthorized, "ERR_UNAUTHORIZED", "Current password is incorrect", nil)
+			RespondError(w, http.StatusUnauthorized, "ERR_UNAUTHORIZED", "現在のパスワードが正しくありません", nil)
 			return
 		}
 		RespondDomainError(w, err)
@@ -102,6 +102,6 @@ func (h *AdminHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 	// 成功レスポンス
 	RespondSuccess(w, map[string]string{
-		"message": "Password changed successfully",
+		"message": "パスワードを変更しました",
 	})
 }

--- a/backend/internal/interface/rest/attendance_handler.go
+++ b/backend/internal/interface/rest/attendance_handler.go
@@ -135,11 +135,11 @@ func (h *AttendanceHandler) CreateCollection(w http.ResponseWriter, r *http.Requ
 
 	// バリデーション
 	if req.Title == "" {
-		RespondBadRequest(w, "title is required")
+		RespondBadRequest(w, "タイトルを入力してください")
 		return
 	}
 	if req.TargetType == "" {
-		RespondBadRequest(w, "target_type is required")
+		RespondBadRequest(w, "対象タイプを選択してください")
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h *AttendanceHandler) CreateCollection(w http.ResponseWriter, r *http.Requ
 	for _, dateStr := range req.TargetDates {
 		parsedDate, err := time.Parse(time.RFC3339, dateStr)
 		if err != nil {
-			RespondBadRequest(w, "invalid target_date format: "+dateStr)
+			RespondBadRequest(w, "対象日の形式が正しくありません: "+dateStr)
 			return
 		}
 		targetDates = append(targetDates, parsedDate)
@@ -350,7 +350,7 @@ func (h *AttendanceHandler) GetCollectionByToken(w http.ResponseWriter, r *http.
 	// URLパラメータからtokenを取得
 	token := chi.URLParam(r, "token")
 	if token == "" {
-		RespondNotFound(w, "Collection not found")
+		RespondNotFound(w, "出欠確認が見つかりません")
 		return
 	}
 
@@ -359,7 +359,7 @@ func (h *AttendanceHandler) GetCollectionByToken(w http.ResponseWriter, r *http.
 		PublicToken: token,
 	})
 	if err != nil {
-		RespondNotFound(w, "Collection not found") // トークンエラー → 404（詳細は返さない）
+		RespondNotFound(w, "出欠確認が見つかりません") // トークンエラー → 404（詳細は返さない）
 		return
 	}
 
@@ -401,7 +401,7 @@ func (h *AttendanceHandler) SubmitResponse(w http.ResponseWriter, r *http.Reques
 	// URLパラメータからtokenを取得
 	token := chi.URLParam(r, "token")
 	if token == "" {
-		RespondNotFound(w, "Collection not found") // トークンエラー → 404
+		RespondNotFound(w, "出欠確認が見つかりません") // トークンエラー → 404
 		return
 	}
 
@@ -414,15 +414,15 @@ func (h *AttendanceHandler) SubmitResponse(w http.ResponseWriter, r *http.Reques
 
 	// バリデーション
 	if req.MemberID == "" {
-		RespondBadRequest(w, "member_id is required")
+		RespondBadRequest(w, "メンバーを選択してください")
 		return
 	}
 	if req.TargetDateID == "" {
-		RespondBadRequest(w, "target_date_id is required")
+		RespondBadRequest(w, "対象日を選択してください")
 		return
 	}
 	if req.Response == "" {
-		RespondBadRequest(w, "response is required")
+		RespondBadRequest(w, "回答を選択してください")
 		return
 	}
 
@@ -438,13 +438,13 @@ func (h *AttendanceHandler) SubmitResponse(w http.ResponseWriter, r *http.Reques
 		// エラーハンドリング（トークンエラー → 404, メンバーエラー → 400）
 		switch {
 		case errors.Is(err, attendance.ErrCollectionNotFound):
-			RespondNotFound(w, "Collection not found") // トークンエラー → 404（詳細は返さない）
+			RespondNotFound(w, "出欠確認が見つかりません") // トークンエラー → 404（詳細は返さない）
 		case errors.Is(err, attendance.ErrMemberNotAllowed):
-			RespondBadRequest(w, "Member not allowed") // メンバーエラー → 400（詳細は返さない）
+			RespondBadRequest(w, "このメンバーは回答できません") // メンバーエラー → 400（詳細は返さない）
 		case errors.Is(err, domainAttendance.ErrCollectionClosed):
-			RespondConflict(w, "Collection is closed")
+			RespondConflict(w, "この出欠確認は締め切られています")
 		case errors.Is(err, domainAttendance.ErrDeadlinePassed):
-			RespondConflict(w, "Deadline has passed")
+			RespondConflict(w, "回答期限が過ぎています")
 		default:
 			RespondDomainError(w, err)
 		}

--- a/backend/internal/interface/rest/auth_handler.go
+++ b/backend/internal/interface/rest/auth_handler.go
@@ -47,11 +47,11 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	// バリデーション
 	if req.Email == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "email is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "メールアドレスを入力してください", nil)
 		return
 	}
 	if req.Password == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "password is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "パスワードを入力してください", nil)
 		return
 	}
 
@@ -64,9 +64,9 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		// エラーコード変換
 		switch {
 		case errors.Is(err, appAuth.ErrInvalidCredentials):
-			RespondError(w, http.StatusUnauthorized, "ERR_UNAUTHORIZED", "Invalid email or password", nil)
+			RespondError(w, http.StatusUnauthorized, "ERR_UNAUTHORIZED", "メールアドレスまたはパスワードが正しくありません", nil)
 		case errors.Is(err, appAuth.ErrAccountDisabled):
-			RespondError(w, http.StatusForbidden, "ERR_FORBIDDEN", "Account is disabled", nil)
+			RespondError(w, http.StatusForbidden, "ERR_FORBIDDEN", "このアカウントは無効化されています", nil)
 		default:
 			RespondInternalError(w)
 		}

--- a/backend/internal/interface/rest/invitation_handler.go
+++ b/backend/internal/interface/rest/invitation_handler.go
@@ -66,11 +66,11 @@ func (h *InvitationHandler) InviteAdmin(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if req.Email == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "email is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "メールアドレスを入力してください", nil)
 		return
 	}
 	if req.Role == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "role is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "権限を選択してください", nil)
 		return
 	}
 
@@ -124,11 +124,11 @@ func (h *InvitationHandler) AcceptInvitation(w http.ResponseWriter, r *http.Requ
 	}
 
 	if req.DisplayName == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "display_name is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "表示名を入力してください", nil)
 		return
 	}
 	if req.Password == "" {
-		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "password is required", nil)
+		RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "パスワードを入力してください", nil)
 		return
 	}
 
@@ -140,9 +140,9 @@ func (h *InvitationHandler) AcceptInvitation(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		switch {
 		case errors.Is(err, appAuth.ErrInvalidInvitation):
-			RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "Invalid or expired invitation", nil)
+			RespondError(w, http.StatusBadRequest, "ERR_INVALID_REQUEST", "招待が無効または期限切れです", nil)
 		case errors.Is(err, appAuth.ErrEmailAlreadyExists):
-			RespondError(w, http.StatusConflict, "ERR_CONFLICT", "Email already exists", nil)
+			RespondError(w, http.StatusConflict, "ERR_CONFLICT", "このメールアドレスは既に登録されています", nil)
 		default:
 			RespondDomainError(w, err)
 		}

--- a/backend/internal/interface/rest/license_claim_handler.go
+++ b/backend/internal/interface/rest/license_claim_handler.go
@@ -53,7 +53,7 @@ func (h *LicenseClaimHandler) Claim(w http.ResponseWriter, r *http.Request) {
 		// Delay response to slow down attackers
 		time.Sleep(1 * time.Second)
 		RespondError(w, http.StatusTooManyRequests, "ERR_RATE_LIMITED",
-			"Too many requests. Please try again later.", nil)
+			"リクエストが多すぎます。しばらくしてから再度お試しください。", nil)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (h *LicenseClaimHandler) Claim(w http.ResponseWriter, r *http.Request) {
 	// Validate required fields
 	if req.Email == "" || req.Password == "" || req.DisplayName == "" ||
 		req.TenantName == "" || req.LicenseKey == "" {
-		RespondBadRequest(w, "All fields are required")
+		RespondBadRequest(w, "すべての項目を入力してください")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (h *LicenseClaimHandler) Claim(w http.ResponseWriter, r *http.Request) {
 		TenantName:  output.TenantName,
 		DisplayName: output.DisplayName,
 		Email:       output.Email,
-		Message:     "License claimed successfully. Please log in to continue.",
+		Message:     "登録が完了しました。ログインしてご利用ください。",
 	}
 
 	RespondJSON(w, http.StatusCreated, map[string]interface{}{

--- a/backend/internal/interface/rest/tenant_handler.go
+++ b/backend/internal/interface/rest/tenant_handler.go
@@ -87,7 +87,7 @@ func (h *TenantHandler) UpdateCurrentTenant(w http.ResponseWriter, r *http.Reque
 
 	// バリデーション
 	if req.TenantName == "" {
-		RespondBadRequest(w, "tenant_name is required")
+		RespondBadRequest(w, "テナント名を入力してください")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- ユーザー向けエラーメッセージを英語から日本語に変換
- 内部エラー（Invalid request body等）は維持

## 変更ファイル
- `license_claim_usecase.go`: パスワードの複雑性検証、ライセンスキー検証エラー
- `auth_handler.go`: ログイン検証エラー
- `admin_handler.go`: パスワード変更検証エラー
- `invitation_handler.go`: 招待作成・受諾エラー
- `attendance_handler.go`: 出欠確認回答エラー
- `license_claim_handler.go`: ライセンス登録エラー、レート制限
- `tenant_handler.go`: テナント設定エラー

## Test plan
- [x] Backend builds successfully
- [ ] ログインで不正な認証情報を入力 → 日本語エラーが表示される
- [ ] ライセンス登録でパスワードに大文字なし → 日本語エラーが表示される
- [ ] 出欠確認で期限切れの回答 → 日本語エラーが表示される

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)