### PR TITLE
feat: UI改善 - ダークテーマとアクセントカラーの導入

### DIFF
--- a/web-frontend/src/components/Layout.tsx
+++ b/web-frontend/src/components/Layout.tsx
@@ -21,7 +21,7 @@ export default function Layout() {
   const linkClass = (path: string) =>
     `flex items-center px-4 py-2.5 text-sm font-medium rounded-lg transition-colors ${
       location.pathname.startsWith(path)
-        ? 'bg-indigo-100 text-indigo-700'
+        ? 'bg-accent/10 text-accent-dark border-l-4 border-accent'
         : 'text-gray-700 hover:bg-gray-100'
     }`;
 
@@ -33,9 +33,9 @@ export default function Layout() {
       {/* サイドバー */}
       <aside className="w-56 bg-white shadow-md flex flex-col fixed h-full">
         {/* ロゴ */}
-        <div className="p-4 border-b">
-          <h1 className="text-lg font-bold text-indigo-900">VRC Shift Scheduler</h1>
-          <span className="inline-block mt-1 bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded text-xs font-medium">
+        <div className="p-4 border-b border-gray-200 bg-vrc-dark">
+          <h1 className="text-lg font-bold text-white">VRC Shift Scheduler</h1>
+          <span className="inline-block mt-1 bg-accent text-white px-2 py-0.5 rounded text-xs font-medium">
             {adminRole === 'owner' ? 'オーナー' : 'マネージャー'}
           </span>
         </div>
@@ -58,7 +58,7 @@ export default function Layout() {
               onClick={() => setShowGroupSubmenu(!showGroupSubmenu)}
               className={`w-full flex items-center justify-between px-4 py-2.5 text-sm font-medium rounded-lg transition-colors ${
                 isGroupActive
-                  ? 'bg-indigo-100 text-indigo-700'
+                  ? 'bg-accent/10 text-accent-dark border-l-4 border-accent'
                   : 'text-gray-700 hover:bg-gray-100'
               }`}
             >
@@ -78,7 +78,7 @@ export default function Layout() {
                   to="/role-groups"
                   className={`block px-4 py-2 text-sm rounded-lg transition-colors ${
                     location.pathname.startsWith('/role-groups')
-                      ? 'bg-indigo-50 text-indigo-700'
+                      ? 'bg-accent/10 text-accent-dark'
                       : 'text-gray-600 hover:bg-gray-50'
                   }`}
                 >
@@ -88,7 +88,7 @@ export default function Layout() {
                   to="/groups"
                   className={`block px-4 py-2 text-sm rounded-lg transition-colors ${
                     location.pathname.startsWith('/groups')
-                      ? 'bg-indigo-50 text-indigo-700'
+                      ? 'bg-accent/10 text-accent-dark'
                       : 'text-gray-600 hover:bg-gray-50'
                   }`}
                 >

--- a/web-frontend/src/index.css
+++ b/web-frontend/src/index.css
@@ -1,5 +1,28 @@
 @import "tailwindcss";
 
+/* カスタムテーマ変数（Tailwind 4.x用） */
+@theme {
+  /* VRC Shift Scheduler カスタムカラー */
+  --color-vrc-dark: #191919;
+  --color-vrc-dark-sub: #474747;
+  --color-vrc-dark-light: #4a4a4a;
+
+  /* アクセントカラー（VRChat風パープル系） */
+  --color-accent: #7B68EE;
+  --color-accent-light: #9B89FF;
+  --color-accent-dark: #5B48CE;
+  --color-accent-hover: #8B7AFF;
+
+  /* カスタムシャドウ */
+  --shadow-soft: 0px 0px 5px 0px rgba(0, 0, 0, 0.3);
+  --shadow-footer: 0px -3px 2px 0px rgba(0, 0, 0, 0.2);
+  --shadow-inset-light: inset 0px 0px 0px 1px rgba(255, 255, 255, 0.3);
+  --shadow-inset-input: inset 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
+
+  /* カスタム角丸 */
+  --radius-card: 10px;
+}
+
 /* グローバルスタイル */
 body {
   @apply bg-gray-100 text-gray-900;
@@ -7,23 +30,84 @@ body {
 
 /* カスタムコンポーネントスタイル */
 @layer components {
+  /* プライマリボタン（グラデーション） */
   .btn-primary {
-    @apply px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors;
+    @apply px-4 py-2 text-white font-medium rounded-lg
+      bg-gradient-to-b from-accent-light to-accent-dark
+      hover:from-accent-hover hover:to-accent
+      border border-accent-dark
+      shadow-inset-light
+      transition-all;
   }
 
+  /* セカンダリボタン（シルバー系） */
   .btn-secondary {
-    @apply px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors;
+    @apply px-4 py-2 text-gray-800 font-medium rounded-lg
+      bg-gradient-to-b from-white to-gray-200
+      hover:from-gray-50 hover:to-gray-100
+      border border-gray-300
+      transition-all;
   }
 
+  /* デンジャーボタン */
+  .btn-danger {
+    @apply px-4 py-2 text-white font-medium rounded-lg
+      bg-gradient-to-b from-red-500 to-red-700
+      hover:from-red-400 hover:to-red-600
+      border border-red-700
+      shadow-inset-light
+      transition-all;
+  }
+
+  /* ダークボタン */
+  .btn-dark {
+    @apply px-4 py-2 text-white font-medium rounded-lg
+      bg-gradient-to-b from-gray-600 via-gray-700 to-gray-900
+      hover:from-gray-500 hover:to-gray-800
+      border border-gray-900
+      transition-all;
+  }
+
+  /* カード */
   .card {
-    @apply bg-white rounded-lg shadow-md p-6;
+    @apply bg-white rounded-card shadow-soft p-6 border border-gray-100;
   }
 
+  /* 入力フィールド */
   .input-field {
-    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500;
+    @apply w-full px-3 py-2
+      border border-gray-300 rounded-lg
+      shadow-inset-input
+      focus:outline-none focus:ring-2 focus:ring-accent;
   }
 
+  /* セクションタイトル（orochi風） */
+  .section-title {
+    @apply pl-6 py-2 text-xl font-light text-white
+      bg-vrc-dark border-l-[6px] border-accent
+      mb-4;
+  }
+
+  /* ラベル */
   .label {
     @apply block text-sm font-medium text-gray-700 mb-1;
+  }
+
+  /* テーブルの行ストライプ */
+  .table-striped tbody tr:nth-child(even) {
+    @apply bg-gray-50;
+  }
+
+  /* テーブルヘッダー */
+  .table-header {
+    @apply px-4 py-3 text-left font-semibold text-gray-700
+      bg-gray-100 border-b-2 border-gray-200;
+  }
+
+  /* ソート可能ヘッダー */
+  .table-header-sortable {
+    @apply px-4 py-3 text-left font-semibold text-gray-700
+      bg-gray-100 border-b-2 border-gray-200
+      cursor-pointer hover:bg-accent/10 transition-colors;
   }
 }

--- a/web-frontend/src/pages/AcceptInvitation.tsx
+++ b/web-frontend/src/pages/AcceptInvitation.tsx
@@ -79,7 +79,7 @@ export default function AcceptInvitation() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       {/* ヘッダー */}
-      <header className="bg-indigo-900 text-white shadow">
+      <header className="bg-vrc-dark text-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
         </div>
@@ -108,7 +108,7 @@ export default function AcceptInvitation() {
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
                 placeholder="山田 太郎"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={loading}
                 autoFocus
               />
@@ -124,7 +124,7 @@ export default function AcceptInvitation() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="8文字以上"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={loading}
               />
             </div>
@@ -139,7 +139,7 @@ export default function AcceptInvitation() {
                 value={passwordConfirm}
                 onChange={(e) => setPasswordConfirm(e.target.value)}
                 placeholder="パスワードを再入力"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={loading}
               />
             </div>
@@ -152,7 +152,7 @@ export default function AcceptInvitation() {
 
             <button
               type="submit"
-              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              className="w-full py-3 px-4 bg-accent hover:bg-accent-dark disabled:bg-accent/70 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
               disabled={loading || !displayName.trim() || !password || !passwordConfirm}
             >
               {loading ? (

--- a/web-frontend/src/pages/AdminInvitation.tsx
+++ b/web-frontend/src/pages/AdminInvitation.tsx
@@ -101,7 +101,7 @@ export default function AdminInvitation() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="newadmin@example.com"
-              className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+              className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
               disabled={loading}
               autoFocus
             />
@@ -115,7 +115,7 @@ export default function AdminInvitation() {
               id="role"
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+              className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
               disabled={loading}
             >
               <option value="admin">管理者 (Admin)</option>
@@ -150,7 +150,7 @@ export default function AdminInvitation() {
 
           <button
             type="submit"
-            className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="w-full py-3 px-4 bg-accent hover:bg-accent-dark disabled:bg-accent/70 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
             disabled={loading || !email.trim() || !role}
           >
             {loading ? (

--- a/web-frontend/src/pages/AdminLogin.tsx
+++ b/web-frontend/src/pages/AdminLogin.tsx
@@ -62,7 +62,7 @@ export default function AdminLogin() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       {/* ヘッダー */}
-      <header className="bg-indigo-900 text-white shadow">
+      <header className="bg-vrc-dark text-white shadow-soft">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
         </div>
@@ -70,7 +70,7 @@ export default function AdminLogin() {
 
       {/* メインコンテンツ */}
       <main className="flex-1 flex items-center justify-center p-4">
-        <div className="bg-white rounded-lg shadow-md max-w-md w-full p-8">
+        <div className="bg-white rounded-card shadow-soft max-w-md w-full p-10 border border-gray-200">
           <div className="text-center mb-8">
             <h2 className="text-2xl font-bold text-gray-900 mb-2">
               ログイン
@@ -91,7 +91,7 @@ export default function AdminLogin() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="admin@example.com"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-400 shadow-inset-input focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={loading}
                 autoFocus
               />
@@ -107,20 +107,20 @@ export default function AdminLogin() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="••••••••"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-400 shadow-inset-input focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={loading}
               />
             </div>
 
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-md p-3">
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3">
                 <p className="text-sm text-red-600">{error}</p>
               </div>
             )}
 
             <button
               type="submit"
-              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              className="w-full py-3 px-4 bg-gradient-to-b from-accent-light to-accent-dark hover:from-accent-hover hover:to-accent disabled:from-gray-400 disabled:to-gray-500 text-white font-semibold rounded-lg border border-accent-dark shadow-inset-light transition-all focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
               disabled={loading || !email.trim() || !password}
             >
               {loading ? (
@@ -140,9 +140,9 @@ export default function AdminLogin() {
       </main>
 
       {/* フッター */}
-      <footer className="bg-white border-t">
+      <footer className="bg-vrc-dark shadow-footer">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <p className="text-center text-sm text-gray-500">
+          <p className="text-center text-sm text-gray-400">
             VRC Shift Scheduler
           </p>
         </div>

--- a/web-frontend/src/pages/AssignShift.tsx
+++ b/web-frontend/src/pages/AssignShift.tsx
@@ -322,7 +322,7 @@ export default function AssignShift() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -424,7 +424,7 @@ export default function AssignShift() {
                   {tableFilterRoleIds.length > 0 && (
                     <button
                       onClick={() => setTableFilterRoleIds([])}
-                      className="text-xs text-indigo-600 hover:text-indigo-800"
+                      className="text-xs text-accent hover:text-accent-dark"
                     >
                       クリア
                     </button>
@@ -445,7 +445,7 @@ export default function AssignShift() {
                         }}
                         className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium transition-all ${
                           isSelected
-                            ? 'ring-2 ring-offset-1 ring-indigo-500'
+                            ? 'ring-2 ring-offset-1 ring-accent'
                             : 'opacity-60 hover:opacity-100'
                         }`}
                         style={{
@@ -557,7 +557,7 @@ export default function AssignShift() {
                       <button
                         type="button"
                         onClick={() => setMemberFilterRoleIds([])}
-                        className="text-xs text-indigo-600 hover:text-indigo-800"
+                        className="text-xs text-accent hover:text-accent-dark"
                       >
                         クリア
                       </button>
@@ -579,7 +579,7 @@ export default function AssignShift() {
                           }}
                           className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium transition-all ${
                             isSelected
-                              ? 'ring-2 ring-offset-1 ring-indigo-500'
+                              ? 'ring-2 ring-offset-1 ring-accent'
                               : 'opacity-60 hover:opacity-100'
                           }`}
                           style={{
@@ -626,7 +626,7 @@ export default function AssignShift() {
                           checked={selectedMemberIds.includes(member.member_id)}
                           onChange={() => handleToggleMember(member.member_id)}
                           disabled={submitting}
-                          className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                          className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
                         />
                         <div className="ml-3 flex items-center gap-2">
                           <span className="text-sm text-gray-900">{member.display_name}</span>

--- a/web-frontend/src/pages/AttendanceDetail.tsx
+++ b/web-frontend/src/pages/AttendanceDetail.tsx
@@ -124,7 +124,7 @@ export default function AttendanceDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -135,7 +135,7 @@ export default function AttendanceDetail() {
       <div className="max-w-4xl mx-auto">
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <p className="text-red-800">{error || '出欠確認が見つかりません'}</p>
-          <Link to="/attendance" className="text-indigo-600 hover:underline mt-4 inline-block">
+          <Link to="/attendance" className="text-accent hover:underline mt-4 inline-block">
             ← 出欠確認一覧に戻る
           </Link>
         </div>
@@ -278,7 +278,7 @@ export default function AttendanceDetail() {
             />
             <button
               onClick={handleCopy}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition text-sm whitespace-nowrap"
+              className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition text-sm whitespace-nowrap"
             >
               {copied ? '✓ コピー済み' : 'URLをコピー'}
             </button>

--- a/web-frontend/src/pages/AttendanceList.tsx
+++ b/web-frontend/src/pages/AttendanceList.tsx
@@ -155,7 +155,7 @@ export default function AttendanceList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -172,7 +172,7 @@ export default function AttendanceList() {
         </div>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors font-medium"
+          className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-dark transition-colors font-medium"
         >
           {showCreateForm ? 'キャンセル' : '+ 新規作成'}
         </button>
@@ -194,7 +194,7 @@ export default function AttendanceList() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="例：12月のシフト出欠確認"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -208,7 +208,7 @@ export default function AttendanceList() {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 placeholder="詳細な説明や注意事項を入力してください"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -224,7 +224,7 @@ export default function AttendanceList() {
                       type="date"
                       value={date}
                       onChange={(e) => handleDateChange(index, e.target.value)}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                       disabled={submitting}
                     />
                     {targetDates.length > 1 && (
@@ -243,7 +243,7 @@ export default function AttendanceList() {
               <button
                 type="button"
                 onClick={handleAddDate}
-                className="mt-2 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 rounded-md transition"
+                className="mt-2 px-3 py-1 text-sm text-accent hover:bg-accent/10 rounded-md transition"
                 disabled={submitting}
               >
                 + 対象日を追加
@@ -258,7 +258,7 @@ export default function AttendanceList() {
                 type="datetime-local"
                 value={deadline}
                 onChange={(e) => setDeadline(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -280,7 +280,7 @@ export default function AttendanceList() {
                       disabled={submitting}
                       className={`px-3 py-1.5 rounded-full text-sm font-medium transition ${
                         selectedGroupIds.includes(group.group_id)
-                          ? 'bg-indigo-600 text-white'
+                          ? 'bg-accent text-white'
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                       }`}
                       style={
@@ -294,7 +294,7 @@ export default function AttendanceList() {
                   ))}
                 </div>
                 {selectedGroupIds.length > 0 && (
-                  <p className="mt-2 text-xs text-indigo-600">
+                  <p className="mt-2 text-xs text-accent">
                     {selectedGroupIds.length}個のグループを選択中
                   </p>
                 )}
@@ -310,7 +310,7 @@ export default function AttendanceList() {
             <button
               type="submit"
               disabled={submitting || !title.trim()}
-              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '作成中...' : '出欠確認を作成'}
             </button>
@@ -434,7 +434,7 @@ export default function AttendanceList() {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <button
                         onClick={() => navigate(`/attendance/${collection.collection_id}`)}
-                        className="text-indigo-600 hover:text-indigo-900 transition"
+                        className="text-accent hover:text-accent-dark transition"
                       >
                         詳細
                       </button>
@@ -447,9 +447,9 @@ export default function AttendanceList() {
         </div>
       </div>
 
-      <div className="mt-6 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
-        <h3 className="text-sm font-semibold text-indigo-900 mb-2">💡 使い方</h3>
-        <ul className="text-sm text-indigo-800 space-y-1 list-disc list-inside">
+      <div className="mt-6 p-4 bg-accent/10 border border-accent/30 rounded-lg">
+        <h3 className="text-sm font-semibold text-accent-dark mb-2">💡 使い方</h3>
+        <ul className="text-sm text-accent-dark space-y-1 list-disc list-inside">
           <li>出欠確認を作成すると公開URLが発行されます</li>
           <li>複数の対象日を設定して、メンバーに各日の出欠を回答してもらえます</li>
           <li>URLをメンバーに送信して、各日の出欠を回答してもらいましょう</li>

--- a/web-frontend/src/pages/BusinessDayList.tsx
+++ b/web-frontend/src/pages/BusinessDayList.tsx
@@ -105,7 +105,7 @@ export default function BusinessDayList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -215,7 +215,7 @@ export default function BusinessDayList() {
                 <select
                   value={selectedMonth}
                   onChange={(e) => setSelectedMonth(e.target.value)}
-                  className="flex-1 px-4 py-2 text-center text-lg font-bold text-gray-900 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  className="flex-1 px-4 py-2 text-center text-lg font-bold text-gray-900 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent"
                 >
                   {sortedKeys.map((monthKey) => {
                     const [y, m] = monthKey.split('-');
@@ -469,11 +469,11 @@ function CreateBusinessDayModal({
             </div>
           </div>
 
-          <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-3 mb-4">
-            <p className="text-xs text-indigo-800">
+          <div className="bg-accent/10 border border-accent/30 rounded-lg p-3 mb-4">
+            <p className="text-xs text-accent-dark">
               💡 深夜営業の場合、終了時刻が開始時刻より前でもOKです（例: 21:30-02:00）
             </p>
-            <p className="text-xs text-indigo-800 mt-1">
+            <p className="text-xs text-accent-dark mt-1">
               📋 手動で追加した営業日は「特別営業」として登録されます
             </p>
           </div>
@@ -575,14 +575,14 @@ function CreateBusinessDayModal({
                           return (
                             <tr
                               key={candidate.candidate_id}
-                              className={isSelected ? 'bg-indigo-50' : 'hover:bg-gray-50'}
+                              className={isSelected ? 'bg-accent/10' : 'hover:bg-gray-50'}
                               onClick={() => setTargetDate(candidateDateStr)}
                               style={{ cursor: 'pointer' }}
                             >
                               <td className="px-3 py-2">
                                 <div className="flex items-center gap-2">
-                                  {isSelected && <span className="text-indigo-600">→</span>}
-                                  <span className={isSelected ? 'font-semibold text-indigo-900' : ''}>
+                                  {isSelected && <span className="text-accent">→</span>}
+                                  <span className={isSelected ? 'font-semibold text-accent-dark' : ''}>
                                     {new Date(candidate.date).toLocaleDateString('ja-JP', {
                                       month: '2-digit',
                                       day: '2-digit',

--- a/web-frontend/src/pages/EventList.tsx
+++ b/web-frontend/src/pages/EventList.tsx
@@ -171,7 +171,7 @@ export default function EventList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -223,7 +223,7 @@ export default function EventList() {
                 <span
                   className={`inline-block px-2 py-1 text-xs font-semibold rounded ${
                     event.event_type === 'normal'
-                      ? 'bg-indigo-100 text-indigo-800'
+                      ? 'bg-accent/10 text-accent-dark'
                       : 'bg-purple-100 text-purple-800'
                   }`}
                 >
@@ -247,7 +247,7 @@ export default function EventList() {
                       value={editingName}
                       onChange={(e) => setEditingName(e.target.value)}
                       onKeyDown={(e) => handleEditKeyDown(event.event_id, e)}
-                      className="flex-1 px-2 py-1 text-lg font-bold border border-indigo-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      className="flex-1 px-2 py-1 text-lg font-bold border border-accent/50 rounded focus:outline-none focus:ring-2 focus:ring-accent"
                       disabled={savingEventId === event.event_id}
                     />
                     <button
@@ -279,7 +279,7 @@ export default function EventList() {
                   </h3>
                   <button
                     onClick={(e) => handleStartEdit(event, e)}
-                    className="p-1 text-gray-400 hover:text-indigo-600 transition-colors"
+                    className="p-1 text-gray-400 hover:text-accent transition-colors"
                     title="イベント名を編集"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -545,8 +545,8 @@ function CreateEventModal({
                 </div>
               </div>
 
-              <div className="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
-                <p className="text-sm text-indigo-800">
+              <div className="mb-4 p-3 bg-accent/10 border border-accent/30 rounded-lg">
+                <p className="text-sm text-accent-dark">
                   定期イベントを作成後、「営業日を自動生成」ボタンで今月〜来月の営業日をまとめて作成できます。
                 </p>
               </div>
@@ -690,7 +690,7 @@ function EventGroupModal({
 
         {loading ? (
           <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mx-auto"></div>
             <p className="mt-2 text-gray-600 text-sm">読み込み中...</p>
           </div>
         ) : (
@@ -718,7 +718,7 @@ function EventGroupModal({
                         type="checkbox"
                         checked={selectedMemberGroups.includes(group.group_id)}
                         onChange={() => toggleMemberGroup(group.group_id)}
-                        className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                        className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
                       />
                       <span
                         className="w-3 h-3 rounded-full"
@@ -754,7 +754,7 @@ function EventGroupModal({
                         type="checkbox"
                         checked={selectedRoleGroups.includes(group.group_id)}
                         onChange={() => toggleRoleGroup(group.group_id)}
-                        className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                        className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
                       />
                       <span
                         className="w-3 h-3 rounded-full"

--- a/web-frontend/src/pages/MemberGroupList.tsx
+++ b/web-frontend/src/pages/MemberGroupList.tsx
@@ -87,7 +87,7 @@ export default function MemberGroupList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -141,7 +141,7 @@ export default function MemberGroupList() {
                   </button>
                   <button
                     onClick={() => setEditingGroup(group)}
-                    className="text-indigo-600 hover:text-indigo-800 text-sm"
+                    className="text-accent hover:text-accent-dark text-sm"
                   >
                     編集
                   </button>
@@ -464,7 +464,7 @@ function AssignMembersModal({
             <button
               type="button"
               onClick={selectAll}
-              className="text-xs text-indigo-600 hover:text-indigo-800"
+              className="text-xs text-accent hover:text-accent-dark"
             >
               全選択
             </button>
@@ -498,7 +498,7 @@ function AssignMembersModal({
                       checked={selectedMemberIds.includes(member.member_id)}
                       onChange={() => toggleMember(member.member_id)}
                       disabled={loading}
-                      className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
                     />
                     <span className="ml-3 text-sm text-gray-900">{member.display_name}</span>
                   </label>

--- a/web-frontend/src/pages/Members.tsx
+++ b/web-frontend/src/pages/Members.tsx
@@ -235,7 +235,7 @@ export default function Members() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -279,7 +279,7 @@ export default function Members() {
               {filterGroupIds.length > 0 && (
                 <button
                   onClick={() => setFilterGroupIds([])}
-                  className="text-xs text-indigo-600 hover:text-indigo-800"
+                  className="text-xs text-accent hover:text-accent-dark"
                 >
                   クリア
                 </button>
@@ -300,7 +300,7 @@ export default function Members() {
                     }}
                     className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                       isSelected
-                        ? 'ring-2 ring-offset-1 ring-indigo-500'
+                        ? 'ring-2 ring-offset-1 ring-accent'
                         : 'opacity-60 hover:opacity-100'
                     }`}
                     style={{
@@ -331,7 +331,7 @@ export default function Members() {
               {filterRoleIds.length > 0 && (
                 <button
                   onClick={() => setFilterRoleIds([])}
-                  className="text-xs text-indigo-600 hover:text-indigo-800"
+                  className="text-xs text-accent hover:text-accent-dark"
                 >
                   クリア
                 </button>
@@ -352,7 +352,7 @@ export default function Members() {
                     }}
                     className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                       isSelected
-                        ? 'ring-2 ring-offset-1 ring-indigo-500'
+                        ? 'ring-2 ring-offset-1 ring-accent'
                         : 'opacity-60 hover:opacity-100'
                     }`}
                     style={{
@@ -442,7 +442,7 @@ export default function Members() {
                   <td className="px-4 py-3 text-sm text-right space-x-3">
                     <button
                       onClick={() => handleOpenEditForm(member)}
-                      className="text-indigo-600 hover:text-indigo-800 font-medium"
+                      className="text-accent hover:text-accent-dark font-medium"
                     >
                       編集
                     </button>
@@ -667,7 +667,7 @@ function ActualAttendanceModal({
 
         {loading ? (
           <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : data && data.target_dates && data.target_dates.length > 0 && displayedAttendances.length > 0 ? (
@@ -765,7 +765,7 @@ function AttendanceConfirmationModal({
 
         {loading ? (
           <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : data && data.target_dates && data.target_dates.length > 0 && displayedAttendances.length > 0 ? (

--- a/web-frontend/src/pages/RoleGroupList.tsx
+++ b/web-frontend/src/pages/RoleGroupList.tsx
@@ -92,7 +92,7 @@ export default function RoleGroupList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -147,7 +147,7 @@ export default function RoleGroupList() {
                   </button>
                   <button
                     onClick={() => setEditingGroup(group)}
-                    className="text-indigo-600 hover:text-indigo-800 text-sm"
+                    className="text-accent hover:text-accent-dark text-sm"
                   >
                     編集
                   </button>
@@ -470,7 +470,7 @@ function AssignRolesModal({
             <button
               type="button"
               onClick={selectAll}
-              className="text-xs text-indigo-600 hover:text-indigo-800"
+              className="text-xs text-accent hover:text-accent-dark"
             >
               全選択
             </button>
@@ -504,7 +504,7 @@ function AssignRolesModal({
                       checked={selectedRoleIds.includes(role.role_id)}
                       onChange={() => toggleRole(role.role_id)}
                       disabled={loading}
-                      className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-accent border-gray-300 rounded focus:ring-accent"
                     />
                     <div className="flex items-center gap-2 ml-3">
                       {role.color && (

--- a/web-frontend/src/pages/RoleList.tsx
+++ b/web-frontend/src/pages/RoleList.tsx
@@ -61,7 +61,7 @@ export default function RoleList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -109,7 +109,7 @@ export default function RoleList() {
                 <div className="flex gap-2">
                   <button
                     onClick={() => setEditingRole(role)}
-                    className="text-indigo-600 hover:text-indigo-800 text-sm"
+                    className="text-accent hover:text-accent-dark text-sm"
                   >
                     編集
                   </button>

--- a/web-frontend/src/pages/ScheduleDetail.tsx
+++ b/web-frontend/src/pages/ScheduleDetail.tsx
@@ -98,7 +98,7 @@ export default function ScheduleDetail() {
       case 'open':
         return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-green-100 text-green-800">受付中</span>;
       case 'decided':
-        return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-indigo-100 text-indigo-800">決定済み</span>;
+        return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-accent/10 text-accent-dark">決定済み</span>;
       case 'closed':
         return <span className="px-3 py-1 text-sm font-semibold rounded-full bg-gray-100 text-gray-800">締切済み</span>;
       default:
@@ -109,7 +109,7 @@ export default function ScheduleDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -120,7 +120,7 @@ export default function ScheduleDetail() {
       <div className="max-w-4xl mx-auto">
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <p className="text-red-800">{error || '日程調整が見つかりません'}</p>
-          <Link to="/schedules" className="text-indigo-600 hover:underline mt-4 inline-block">
+          <Link to="/schedules" className="text-accent hover:underline mt-4 inline-block">
             ← 日程調整一覧に戻る
           </Link>
         </div>
@@ -255,7 +255,7 @@ export default function ScheduleDetail() {
             />
             <button
               onClick={handleCopy}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition text-sm whitespace-nowrap"
+              className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition text-sm whitespace-nowrap"
             >
               {copied ? '✓ コピー済み' : 'URLをコピー'}
             </button>

--- a/web-frontend/src/pages/ScheduleList.tsx
+++ b/web-frontend/src/pages/ScheduleList.tsx
@@ -147,7 +147,7 @@ export default function ScheduleList() {
       case 'open':
         return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">受付中</span>;
       case 'decided':
-        return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-indigo-100 text-indigo-800">決定済み</span>;
+        return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-accent/10 text-accent-dark">決定済み</span>;
       case 'closed':
         return <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-800">締切済み</span>;
       default:
@@ -158,7 +158,7 @@ export default function ScheduleList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -175,7 +175,7 @@ export default function ScheduleList() {
         </div>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors font-medium"
+          className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-dark transition-colors font-medium"
         >
           {showCreateForm ? 'キャンセル' : '+ 新規作成'}
         </button>
@@ -197,7 +197,7 @@ export default function ScheduleList() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="例：忘年会の日程調整"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -211,7 +211,7 @@ export default function ScheduleList() {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 placeholder="詳細な説明や注意事項を入力してください"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -227,7 +227,7 @@ export default function ScheduleList() {
                       type="datetime-local"
                       value={date}
                       onChange={(e) => handleDateChange(index, e.target.value)}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                       disabled={submitting}
                     />
                     {candidateDates.length > 1 && (
@@ -246,7 +246,7 @@ export default function ScheduleList() {
               <button
                 type="button"
                 onClick={handleAddDate}
-                className="mt-2 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 rounded-md transition"
+                className="mt-2 px-3 py-1 text-sm text-accent hover:bg-accent/10 rounded-md transition"
                 disabled={submitting}
               >
                 + 候補日を追加
@@ -261,7 +261,7 @@ export default function ScheduleList() {
                 type="datetime-local"
                 value={deadline}
                 onChange={(e) => setDeadline(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 disabled={submitting}
               />
             </div>
@@ -283,7 +283,7 @@ export default function ScheduleList() {
                       disabled={submitting}
                       className={`px-3 py-1.5 rounded-full text-sm font-medium transition ${
                         selectedGroupIds.includes(group.group_id)
-                          ? 'bg-indigo-600 text-white'
+                          ? 'bg-accent text-white'
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                       }`}
                       style={
@@ -297,7 +297,7 @@ export default function ScheduleList() {
                   ))}
                 </div>
                 {selectedGroupIds.length > 0 && (
-                  <p className="mt-2 text-xs text-indigo-600">
+                  <p className="mt-2 text-xs text-accent">
                     {selectedGroupIds.length}個のグループを選択中
                   </p>
                 )}
@@ -313,7 +313,7 @@ export default function ScheduleList() {
             <button
               type="submit"
               disabled={submitting || !title.trim()}
-              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '作成中...' : '日程調整を作成'}
             </button>
@@ -437,7 +437,7 @@ export default function ScheduleList() {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <button
                         onClick={() => navigate(`/schedules/${schedule.schedule_id}`)}
-                        className="text-indigo-600 hover:text-indigo-900 transition"
+                        className="text-accent hover:text-accent-dark transition"
                       >
                         詳細
                       </button>
@@ -450,9 +450,9 @@ export default function ScheduleList() {
         </div>
       </div>
 
-      <div className="mt-6 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
-        <h3 className="text-sm font-semibold text-indigo-900 mb-2">💡 使い方</h3>
-        <ul className="text-sm text-indigo-800 space-y-1 list-disc list-inside">
+      <div className="mt-6 p-4 bg-accent/10 border border-accent/30 rounded-lg">
+        <h3 className="text-sm font-semibold text-accent-dark mb-2">💡 使い方</h3>
+        <ul className="text-sm text-accent-dark space-y-1 list-disc list-inside">
           <li>日程調整を作成すると公開URLが発行されます</li>
           <li>URLをメンバーに送信して、参加可能な日程を回答してもらいましょう</li>
           <li>メンバーは候補日の中から参加可能な日程を複数選択できます</li>

--- a/web-frontend/src/pages/Settings.tsx
+++ b/web-frontend/src/pages/Settings.tsx
@@ -187,7 +187,7 @@ export default function Settings() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -212,7 +212,7 @@ export default function Settings() {
       {/* テナント情報セクション */}
       <div className="card mb-6">
         <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <svg className="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
           組織情報
@@ -251,7 +251,7 @@ export default function Settings() {
                 <span className="text-gray-900">{tenant?.tenant_name}</span>
                 <button
                   onClick={() => setEditingTenantName(true)}
-                  className="p-1 text-gray-400 hover:text-indigo-600 transition-colors"
+                  className="p-1 text-gray-400 hover:text-accent transition-colors"
                   title="組織名を編集"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web-frontend/src/pages/ShiftSlotList.tsx
+++ b/web-frontend/src/pages/ShiftSlotList.tsx
@@ -67,7 +67,7 @@ export default function ShiftSlotList() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -184,7 +184,7 @@ export default function ShiftSlotList() {
                           {assignments.map((assignment) => (
                             <span
                               key={assignment.assignment_id}
-                              className="inline-block px-2 py-1 bg-indigo-100 text-indigo-800 rounded text-xs"
+                              className="inline-block px-2 py-1 bg-accent/10 text-accent-dark rounded text-xs"
                             >
                               {assignment.member_display_name || assignment.member_id}
                             </span>
@@ -480,7 +480,7 @@ function ApplyTemplateModal({
 
         {loadingTemplates ? (
           <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
             <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
         ) : (
@@ -517,17 +517,17 @@ function ApplyTemplateModal({
             </div>
 
             {selectedTemplate && (
-              <div className="mb-4 bg-indigo-50 border border-indigo-200 rounded-lg p-4">
-                <h4 className="font-semibold text-indigo-900 mb-2">
+              <div className="mb-4 bg-accent/10 border border-accent/30 rounded-lg p-4">
+                <h4 className="font-semibold text-accent-dark mb-2">
                   {selectedTemplate.template_name}
                 </h4>
                 {selectedTemplate.description && (
-                  <p className="text-sm text-indigo-800 mb-3">{selectedTemplate.description}</p>
+                  <p className="text-sm text-accent-dark mb-3">{selectedTemplate.description}</p>
                 )}
                 <div className="space-y-2">
-                  <p className="text-xs font-semibold text-indigo-900">作成されるシフト枠:</p>
+                  <p className="text-xs font-semibold text-accent-dark">作成されるシフト枠:</p>
                   {(selectedTemplate.items || []).map((item, index) => (
-                    <div key={index} className="text-xs text-indigo-800">
+                    <div key={index} className="text-xs text-accent-dark">
                       • {item.slot_name} ({item.instance_name}) - {item.start_time.substring(0, 5)}~
                       {item.end_time.substring(0, 5)} ({item.required_count}名)
                     </div>

--- a/web-frontend/src/pages/TemplateDetail.tsx
+++ b/web-frontend/src/pages/TemplateDetail.tsx
@@ -59,7 +59,7 @@ export default function TemplateDetail() {
   if (loading) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -72,7 +72,7 @@ export default function TemplateDetail() {
           <p className="text-sm text-red-800">{error || 'テンプレートが見つかりません'}</p>
         </div>
         <div className="mt-4">
-          <Link to={`/events/${eventId}/templates`} className="text-indigo-600 hover:text-indigo-800">
+          <Link to={`/events/${eventId}/templates`} className="text-accent hover:text-accent-dark">
             ← テンプレート一覧に戻る
           </Link>
         </div>
@@ -103,7 +103,7 @@ export default function TemplateDetail() {
           <div className="flex gap-2 ml-4">
             <Link
               to={`/events/${eventId}/templates/${templateId}/edit`}
-              className="bg-indigo-100 hover:bg-indigo-200 text-indigo-700 px-4 py-2 rounded-lg text-sm font-medium"
+              className="bg-accent/10 hover:bg-accent/20 text-accent-dark px-4 py-2 rounded-lg text-sm font-medium"
             >
               編集
             </Link>
@@ -149,7 +149,7 @@ export default function TemplateDetail() {
                       優先度: {item.priority}
                     </p>
                   </div>
-                  <span className="bg-indigo-100 text-indigo-800 text-xs font-medium px-2.5 py-0.5 rounded">
+                  <span className="bg-accent/10 text-accent-dark text-xs font-medium px-2.5 py-0.5 rounded">
                     {item.required_count}名
                   </span>
                 </div>
@@ -171,9 +171,9 @@ export default function TemplateDetail() {
       </div>
 
       {/* 使用方法の説明 */}
-      <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mt-6">
-        <h4 className="font-semibold text-indigo-900 mb-2">💡 テンプレートの使い方</h4>
-        <p className="text-sm text-indigo-800">
+      <div className="bg-accent/10 border border-accent/30 rounded-lg p-4 mt-6">
+        <h4 className="font-semibold text-accent-dark mb-2">💡 テンプレートの使い方</h4>
+        <p className="text-sm text-accent-dark">
           このテンプレートは営業日作成時に選択することで、登録されているシフト枠を自動的に作成します。
           営業日一覧ページから「営業日を追加」を選択し、テンプレートを選んでください。
         </p>

--- a/web-frontend/src/pages/TemplateForm.tsx
+++ b/web-frontend/src/pages/TemplateForm.tsx
@@ -146,7 +146,7 @@ export default function TemplateForm() {
   if (loadingData) {
     return (
       <div className="text-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
         <p className="mt-4 text-gray-600">読み込み中...</p>
       </div>
     );
@@ -212,7 +212,7 @@ export default function TemplateForm() {
               type="button"
               onClick={addItem}
               disabled={loading}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm flex items-center"
+              className="bg-accent hover:bg-accent-dark text-white px-4 py-2 rounded-lg text-sm flex items-center"
             >
               <svg
                 className="w-5 h-5 mr-1"
@@ -238,7 +238,7 @@ export default function TemplateForm() {
                 type="button"
                 onClick={addItem}
                 disabled={loading}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm"
+                className="bg-accent hover:bg-accent-dark text-white px-4 py-2 rounded-lg text-sm"
               >
                 最初のシフト枠を追加
               </button>
@@ -358,7 +358,7 @@ export default function TemplateForm() {
           <button
             type="submit"
             disabled={loading || items.length === 0}
-            className="flex-1 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 bg-accent hover:bg-accent-dark text-white px-6 py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? '保存中...' : isEditMode ? '更新する' : '作成する'}
           </button>

--- a/web-frontend/src/pages/TemplateList.tsx
+++ b/web-frontend/src/pages/TemplateList.tsx
@@ -80,7 +80,7 @@ const TemplateList = () => {
         </div>
         <button
           onClick={() => navigate(`/events/${eventId}/templates/new`)}
-          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg flex items-center"
+          className="bg-accent hover:bg-accent-dark text-white px-4 py-2 rounded-lg flex items-center"
         >
           <svg
             className="w-5 h-5 mr-2"
@@ -121,7 +121,7 @@ const TemplateList = () => {
           <div className="mt-6">
             <button
               onClick={() => navigate(`/events/${eventId}/templates/new`)}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg"
+              className="bg-accent hover:bg-accent-dark text-white px-4 py-2 rounded-lg"
             >
               テンプレートを作成
             </button>
@@ -138,7 +138,7 @@ const TemplateList = () => {
                 <h3 className="text-lg font-semibold text-gray-900 flex-1">
                   {template.template_name}
                 </h3>
-                <span className="bg-indigo-100 text-indigo-800 text-xs font-medium px-2.5 py-0.5 rounded">
+                <span className="bg-accent/10 text-accent-dark text-xs font-medium px-2.5 py-0.5 rounded">
                   {(template.items || []).length} 枠
                 </span>
               </div>
@@ -154,7 +154,7 @@ const TemplateList = () => {
                 <div className="space-y-1">
                   {(template.items || []).slice(0, 3).map((item, index) => (
                     <div key={index} className="text-xs text-gray-600 flex items-center">
-                      <span className="w-2 h-2 bg-indigo-400 rounded-full mr-2"></span>
+                      <span className="w-2 h-2 bg-accent/70 rounded-full mr-2"></span>
                       {item.slot_name} ({item.instance_name}) - {item.start_time.substring(0, 5)}~
                       {item.end_time.substring(0, 5)} ({item.required_count}名)
                     </div>
@@ -176,7 +176,7 @@ const TemplateList = () => {
                 </button>
                 <button
                   onClick={() => navigate(`/events/${eventId}/templates/${template.template_id}/edit`)}
-                  className="flex-1 bg-indigo-100 hover:bg-indigo-200 text-indigo-700 px-3 py-2 rounded text-sm font-medium"
+                  className="flex-1 bg-accent/10 hover:bg-accent/20 text-accent-dark px-3 py-2 rounded text-sm font-medium"
                 >
                   編集
                 </button>

--- a/web-frontend/src/pages/public/AttendanceResponse.tsx
+++ b/web-frontend/src/pages/public/AttendanceResponse.tsx
@@ -139,7 +139,7 @@ export default function AttendanceResponse() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-accent"></div>
           <p className="mt-4 text-gray-600">読み込み中...</p>
         </div>
       </div>
@@ -181,7 +181,7 @@ export default function AttendanceResponse() {
                 setResponses(initialResponses);
                 setNote('');
               }}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition"
+              className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition"
             >
               別の回答を送信
             </button>
@@ -236,7 +236,7 @@ export default function AttendanceResponse() {
               <select
                 value={selectedMemberId}
                 onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 required
                 disabled={collection?.status === 'closed'}
               >
@@ -310,7 +310,7 @@ export default function AttendanceResponse() {
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 placeholder="補足事項があれば入力してください"
                 disabled={collection?.status === 'closed'}
               />
@@ -319,7 +319,7 @@ export default function AttendanceResponse() {
             <button
               type="submit"
               disabled={submitting || collection?.status === 'closed' || targetDates.length === 0}
-              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '送信中...' : '回答を送信'}
             </button>

--- a/web-frontend/src/pages/public/LicenseClaim.tsx
+++ b/web-frontend/src/pages/public/LicenseClaim.tsx
@@ -80,7 +80,7 @@ export default function LicenseClaim() {
     return (
       <div className="min-h-screen bg-gray-100 flex flex-col">
         {/* ヘッダー */}
-        <header className="bg-indigo-900 text-white shadow">
+        <header className="bg-vrc-dark text-white shadow">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
             <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
           </div>
@@ -97,7 +97,7 @@ export default function LicenseClaim() {
             </div>
             <button
               onClick={() => navigate('/login')}
-              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              className="w-full py-3 px-4 bg-accent hover:bg-accent-dark text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
             >
               ログインへ
             </button>
@@ -119,7 +119,7 @@ export default function LicenseClaim() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       {/* ヘッダー */}
-      <header className="bg-indigo-900 text-white shadow">
+      <header className="bg-vrc-dark text-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <h1 className="text-xl font-bold">VRC Shift Scheduler</h1>
         </div>
@@ -150,7 +150,7 @@ export default function LicenseClaim() {
                 value={formData.license_key}
                 onChange={handleLicenseKeyChange}
                 placeholder="XXXX-XXXX-XXXX-XXXX"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition font-mono"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition font-mono"
                 disabled={isLoading}
               />
             </div>
@@ -167,7 +167,7 @@ export default function LicenseClaim() {
                 value={formData.tenant_name}
                 onChange={handleChange}
                 placeholder="VRCイベント名"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={isLoading}
               />
             </div>
@@ -184,7 +184,7 @@ export default function LicenseClaim() {
                 value={formData.display_name}
                 onChange={handleChange}
                 placeholder="管理者"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={isLoading}
               />
             </div>
@@ -202,7 +202,7 @@ export default function LicenseClaim() {
                 value={formData.email}
                 onChange={handleChange}
                 placeholder="admin@example.com"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={isLoading}
               />
             </div>
@@ -220,7 +220,7 @@ export default function LicenseClaim() {
                 value={formData.password}
                 onChange={handleChange}
                 placeholder="••••••••"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={isLoading}
               />
               <p className="mt-1 text-xs text-gray-500">8文字以上</p>
@@ -239,7 +239,7 @@ export default function LicenseClaim() {
                 value={formData.confirmPassword}
                 onChange={handleChange}
                 placeholder="••••••••"
-                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
                 disabled={isLoading}
               />
             </div>
@@ -252,7 +252,7 @@ export default function LicenseClaim() {
 
             <button
               type="submit"
-              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              className="w-full py-3 px-4 bg-accent hover:bg-accent-dark disabled:bg-accent/70 text-white font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
               disabled={isLoading}
             >
               {isLoading ? (
@@ -269,7 +269,7 @@ export default function LicenseClaim() {
             </button>
 
             <div className="text-center">
-              <a href="/login" className="text-sm text-indigo-600 hover:text-indigo-500">
+              <a href="/login" className="text-sm text-accent hover:text-accent">
                 アカウントをお持ちですか？ログイン
               </a>
             </div>

--- a/web-frontend/src/pages/public/ScheduleResponse.tsx
+++ b/web-frontend/src/pages/public/ScheduleResponse.tsx
@@ -159,7 +159,7 @@ export default function ScheduleResponse() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-accent"></div>
           <p className="mt-4 text-gray-600">読み込み中...</p>
         </div>
       </div>
@@ -204,7 +204,7 @@ export default function ScheduleResponse() {
                 });
                 setResponses(initialResponses);
               }}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition"
+              className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition"
             >
               別の回答を送信
             </button>
@@ -266,7 +266,7 @@ export default function ScheduleResponse() {
               <select
                 value={selectedMemberId}
                 onChange={(e) => setSelectedMemberId(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"
                 required
                 disabled={schedule?.status !== 'open'}
               >
@@ -365,7 +365,7 @@ export default function ScheduleResponse() {
                               e.target.value
                             )
                           }
-                          className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                          className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-accent"
                           disabled={schedule?.status !== 'open'}
                         />
                       </div>
@@ -378,7 +378,7 @@ export default function ScheduleResponse() {
             <button
               type="submit"
               disabled={submitting || schedule?.status !== 'open'}
-              className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               {submitting ? '送信中...' : '回答を送信'}
             </button>


### PR DESCRIPTION
## Summary
- orochiプロジェクトを参考にしたUI/UXデザインの改善
- Tailwind 4.x用のカスタムテーマ変数を導入
- ダークテーマヘッダーとVRChat風アクセントカラー(パープル系)を適用
- 全24ファイルでindigo色をaccent色に統一

## 主な変更

### カスタムテーマ (@theme)
- `vrc-dark`: #191919 (ヘッダー/フッター)
- `accent`: #7B68EE (VRChat風パープル)
- `accent-light`: #9B89FF
- `accent-dark`: #5B48CE
- カスタムシャドウ: `soft`, `footer`, `inset-light`, `inset-input`

### UIコンポーネント
- グラデーションボタン: `btn-primary`, `btn-secondary`, `btn-danger`, `btn-dark`
- カード: `card` (rounded-card + shadow-soft)
- 入力フィールド: `input-field` (shadow-inset-input)
- セクションタイトル: `section-title` (左ボーダー + ダーク背景)
- テーブル: `table-header`, `table-header-sortable`, `table-striped`

### ページ別変更
- ログイン画面: グラデーションボタン、インセットシャドウ入力
- サイドバー: ダークヘッダー、アクセントカラーナビゲーション
- 全ページ: indigo → accent色への統一

## Test plan
- [ ] ログイン画面の表示確認
- [ ] サイドバーナビゲーションの動作確認
- [ ] 各ページでのボタン・カード・入力フィールドの表示確認
- [ ] ダークテーマヘッダー/フッターの確認

## 関連Issue
Closes #45, #46, #47, #48, #49, #50, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)