### PR TITLE
fix: ログイン後のリダイレクトが失敗する問題を修正

### DIFF
--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -66,8 +66,8 @@ function App() {
 
   return (
     <Routes>
-      {/* 管理者ログイン */}
-      <Route path="/admin/login" element={<AdminLogin />} />
+      {/* 管理者ログイン（ログイン済みの場合は /events へリダイレクト） */}
+      <Route path="/admin/login" element={isLoggedIn ? <Navigate to="/events" replace /> : <AdminLogin />} />
       <Route path="/login" element={<Navigate to="/admin/login" replace />} />
 
       {/* 招待受理（認証不要） */}

--- a/web-frontend/src/pages/AdminLogin.tsx
+++ b/web-frontend/src/pages/AdminLogin.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { login } from '../lib/api/authApi';
 
 export default function AdminLogin() {
@@ -7,7 +6,6 @@ export default function AdminLogin() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,8 +36,8 @@ export default function AdminLogin() {
       localStorage.setItem('tenant_id', result.tenant_id);
       localStorage.setItem('admin_role', result.role);
 
-      // 管理画面に遷移
-      navigate('/events');
+      // 管理画面に遷移（ページリロードで認証状態を再初期化）
+      window.location.href = '/events';
     } catch (err) {
       if (err instanceof Error) {
         // エラーメッセージに基づいて日本語表示


### PR DESCRIPTION
## Summary

ログイン成功後に `/events` へ遷移せず、ログイン画面に戻ってしまうバグを修正。

### 問題
- `navigate('/events')` を使用すると、`App.tsx` の `isLoggedIn` 状態が古い値のまま再レンダリングされる
- React Router の SPA 内遷移では、useState の初期値が更新されない

### 修正
- `window.location.href = '/events'` を使用してページを完全にリロードし、認証状態を再初期化する

## Test plan
- [ ] ログインして `/events` に正常に遷移することを確認
- [ ] トークンが localStorage に保存されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)