### PR TITLE
fix: ログイン後リダイレクトバグ修正 (v1.1.1)

### DIFF
--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -66,8 +66,8 @@ function App() {
 
   return (
     <Routes>
-      {/* 管理者ログイン */}
-      <Route path="/admin/login" element={<AdminLogin />} />
+      {/* 管理者ログイン（ログイン済みの場合は /events へリダイレクト） */}
+      <Route path="/admin/login" element={isLoggedIn ? <Navigate to="/events" replace /> : <AdminLogin />} />
       <Route path="/login" element={<Navigate to="/admin/login" replace />} />
 
       {/* 招待受理（認証不要） */}

--- a/web-frontend/src/pages/AdminLogin.tsx
+++ b/web-frontend/src/pages/AdminLogin.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { login } from '../lib/api/authApi';
 
 export default function AdminLogin() {
@@ -7,7 +6,6 @@ export default function AdminLogin() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,8 +36,8 @@ export default function AdminLogin() {
       localStorage.setItem('tenant_id', result.tenant_id);
       localStorage.setItem('admin_role', result.role);
 
-      // 管理画面に遷移
-      navigate('/events');
+      // 管理画面に遷移（ページリロードで認証状態を再初期化）
+      window.location.href = '/events';
     } catch (err) {
       if (err instanceof Error) {
         // エラーメッセージに基づいて日本語表示


### PR DESCRIPTION
## Summary

ログイン後リダイレクトバグの修正を main にマージ。

### 修正内容
- ログイン成功後に `/events` に正常に遷移するよう修正
- ログイン済みユーザーがログイン画面にアクセスした場合 `/events` へリダイレクト

## Test plan
- [ ] 本番環境でログイン動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)