### PR TITLE
Release: v1.2.1 - 営業日生成バグ修正と招待ページ改善

### DIFF
--- a/backend/internal/app/event/event_usecase.go
+++ b/backend/internal/app/event/event_usecase.go
@@ -130,9 +130,8 @@ func (uc *CreateEventUsecase) generateBusinessDays(ctx context.Context, e *event
 		}
 
 		if !exists {
-			// 営業日を作成（普通営業 = recurring）
-			// recurring_pattern_id として event_id を使用（イベント自体が定期パターンを定義）
-			eventIDForPattern := e.EventID()
+			// 営業日を作成（定期営業 = recurring）
+			// イベント自体の定期設定から生成する場合は recurring_pattern_id は nil
 			businessDay, err := event.NewEventBusinessDay(
 				time.Now(),
 				e.TenantID(),
@@ -141,7 +140,7 @@ func (uc *CreateEventUsecase) generateBusinessDays(ctx context.Context, e *event
 				*e.DefaultStartTime(),
 				*e.DefaultEndTime(),
 				event.OccurrenceTypeRecurring,
-				&eventIDForPattern,
+				nil,
 			)
 			if err != nil {
 				return err
@@ -396,9 +395,8 @@ func (uc *GenerateBusinessDaysUsecase) generateBusinessDays(ctx context.Context,
 		}
 
 		if !exists {
-			// 営業日を作成（普通営業 = recurring）
-			// recurring_pattern_id として event_id を使用（イベント自体が定期パターンを定義）
-			eventIDForPattern := e.EventID()
+			// 営業日を作成（定期営業 = recurring）
+			// イベント自体の定期設定から生成する場合は recurring_pattern_id は nil
 			businessDay, err := event.NewEventBusinessDay(
 				time.Now(),
 				e.TenantID(),
@@ -407,7 +405,7 @@ func (uc *GenerateBusinessDaysUsecase) generateBusinessDays(ctx context.Context,
 				*e.DefaultStartTime(),
 				*e.DefaultEndTime(),
 				event.OccurrenceTypeRecurring,
-				&eventIDForPattern,
+				nil,
 			)
 			if err != nil {
 				return generatedCount, err

--- a/backend/internal/infra/db/migrations/027_relax_recurring_pattern_constraint.down.sql
+++ b/backend/internal/infra/db/migrations/027_relax_recurring_pattern_constraint.down.sql
@@ -1,0 +1,12 @@
+-- Rollback: 027_relax_recurring_pattern_constraint
+
+-- 新しい制約を削除
+ALTER TABLE event_business_days
+DROP CONSTRAINT IF EXISTS event_business_days_pattern_consistency_check;
+
+-- 元の制約を復元
+ALTER TABLE event_business_days
+ADD CONSTRAINT event_business_days_pattern_consistency_check CHECK (
+    (occurrence_type = 'recurring' AND recurring_pattern_id IS NOT NULL) OR
+    (occurrence_type = 'special' AND recurring_pattern_id IS NULL)
+);

--- a/backend/internal/infra/db/migrations/027_relax_recurring_pattern_constraint.up.sql
+++ b/backend/internal/infra/db/migrations/027_relax_recurring_pattern_constraint.up.sql
@@ -1,0 +1,15 @@
+-- Migration: 027_relax_recurring_pattern_constraint
+-- Description: recurring タイプでも recurring_pattern_id が NULL を許可
+-- イベント自体の定期設定から生成される営業日に対応
+
+-- 既存のCHECK制約を削除
+ALTER TABLE event_business_days
+DROP CONSTRAINT IF EXISTS event_business_days_pattern_consistency_check;
+
+-- 新しいCHECK制約を追加（recurringでもNULLを許可）
+ALTER TABLE event_business_days
+ADD CONSTRAINT event_business_days_pattern_consistency_check CHECK (
+    occurrence_type IN ('recurring', 'special')
+);
+
+COMMENT ON COLUMN event_business_days.recurring_pattern_id IS '生成元の定期パターン（recurring_patternsテーブル使用時のみ、イベント自体の定期設定から生成時はNULL）';

--- a/backend/internal/interface/rest/event_handler.go
+++ b/backend/internal/interface/rest/event_handler.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
@@ -437,6 +438,7 @@ func (h *EventHandler) GenerateBusinessDays(w http.ResponseWriter, r *http.Reque
 
 	output, err := h.generateBusinessDaysUC.Execute(ctx, input)
 	if err != nil {
+		log.Printf("GenerateBusinessDays error for event %s, tenant %s: %v", eventID, tenantID, err)
 		RespondDomainError(w, err)
 		return
 	}

--- a/web-frontend/src/pages/AdminInvitation.tsx
+++ b/web-frontend/src/pages/AdminInvitation.tsx
@@ -4,7 +4,7 @@ import { inviteAdmin } from '../lib/api/invitationApi';
 
 export default function AdminInvitation() {
   const [email, setEmail] = useState('');
-  const [role, setRole] = useState('admin');
+  const [role, setRole] = useState('manager');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
@@ -43,7 +43,7 @@ export default function AdminInvitation() {
 
       // フォームをクリア
       setEmail('');
-      setRole('admin');
+      setRole('manager');
     } catch (err) {
       if (err instanceof Error) {
         // エラーメッセージに基づいて日本語表示
@@ -118,7 +118,6 @@ export default function AdminInvitation() {
               className="w-full px-4 py-3 border border-gray-300 rounded-md text-gray-900 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent transition"
               disabled={loading}
             >
-              <option value="admin">管理者 (Admin)</option>
               <option value="manager">マネージャー (Manager)</option>
             </select>
           </div>


### PR DESCRIPTION
## Summary

- 営業日生成APIの500エラー修正
- 招待ページでマネージャーのみ選択可能に変更
- マイグレーション追加（CHECK制約の緩和）

## Changes from PR #57

### Backend
- `event_usecase.go`: 営業日生成時の`occurrence_type`を`recurring`に設定
- `event_handler.go`: エラー時のログを追加
- マイグレーション追加（027）: `recurring`タイプでも`recurring_pattern_id`がNULLを許可

### Frontend
- `AdminInvitation.tsx`: マネージャーのみ招待可能に変更

## Test plan

- [x] 営業日生成APIが正常動作することを確認
- [x] 生成された営業日が`recurring`タイプであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)