### PR TITLE
feat: [Backend] 日程調整・出欠確認の削除機能を追加 #36

### DIFF
--- a/backend/internal/app/attendance/delete_collection_usecase.go
+++ b/backend/internal/app/attendance/delete_collection_usecase.go
@@ -1,0 +1,51 @@
+package attendance
+
+import (
+	"context"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/attendance"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/services"
+)
+
+type DeleteCollectionUsecase struct {
+	repo  attendance.AttendanceCollectionRepository
+	clock services.Clock
+}
+
+func NewDeleteCollectionUsecase(repo attendance.AttendanceCollectionRepository, clk services.Clock) *DeleteCollectionUsecase {
+	return &DeleteCollectionUsecase{repo: repo, clock: clk}
+}
+
+func (u *DeleteCollectionUsecase) Execute(ctx context.Context, input DeleteCollectionInput) (*DeleteCollectionOutput, error) {
+	tenantID, err := common.ParseTenantID(input.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	collectionID, err := common.ParseCollectionID(input.CollectionID)
+	if err != nil {
+		return nil, err
+	}
+
+	collection, err := u.repo.FindByID(ctx, tenantID, collectionID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := u.clock.Now()
+	if err := collection.Delete(now); err != nil {
+		return nil, err
+	}
+
+	if err := u.repo.Save(ctx, collection); err != nil {
+		return nil, err
+	}
+
+	return &DeleteCollectionOutput{
+		CollectionID: collection.CollectionID().String(),
+		Status:       collection.Status().String(),
+		DeletedAt:    collection.DeletedAt(),
+		UpdatedAt:    collection.UpdatedAt(),
+	}, nil
+}

--- a/backend/internal/app/attendance/dto.go
+++ b/backend/internal/app/attendance/dto.go
@@ -11,29 +11,29 @@ type TargetDateDTO struct {
 
 // CreateCollectionInput represents the input for creating an attendance collection
 type CreateCollectionInput struct {
-	TenantID    string     // from JWT context (管理API)
+	TenantID    string // from JWT context (管理API)
 	Title       string
 	Description string
-	TargetType  string     // "event" or "business_day"
-	TargetID    string     // event_id or business_day_id (optional)
+	TargetType  string      // "event" or "business_day"
+	TargetID    string      // event_id or business_day_id (optional)
 	TargetDates []time.Time // 対象日の配列
 	Deadline    *time.Time
-	GroupIDs    []string   // 対象グループID（複数可）
+	GroupIDs    []string // 対象グループID（複数可）
 }
 
 // CreateCollectionOutput represents the output for creating an attendance collection
 type CreateCollectionOutput struct {
-	CollectionID string    `json:"collection_id"`
-	TenantID     string    `json:"tenant_id"`
-	Title        string    `json:"title"`
-	Description  string    `json:"description"`
-	TargetType   string    `json:"target_type"`
-	TargetID     string    `json:"target_id"`
-	PublicToken  string    `json:"public_token"`
-	Status       string    `json:"status"`
+	CollectionID string     `json:"collection_id"`
+	TenantID     string     `json:"tenant_id"`
+	Title        string     `json:"title"`
+	Description  string     `json:"description"`
+	TargetType   string     `json:"target_type"`
+	TargetID     string     `json:"target_id"`
+	PublicToken  string     `json:"public_token"`
+	Status       string     `json:"status"`
 	Deadline     *time.Time `json:"deadline,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
 
 // SubmitResponseInput represents the input for submitting an attendance response
@@ -86,7 +86,7 @@ type GetCollectionOutput struct {
 	PublicToken  string          `json:"public_token"`
 	Status       string          `json:"status"`
 	Deadline     *time.Time      `json:"deadline,omitempty"`
-	GroupIDs     []string        `json:"group_ids,omitempty"`    // 対象グループID
+	GroupIDs     []string        `json:"group_ids,omitempty"` // 対象グループID
 	CreatedAt    time.Time       `json:"created_at"`
 	UpdatedAt    time.Time       `json:"updated_at"`
 }
@@ -99,18 +99,32 @@ type GetResponsesInput struct {
 
 // ResponseDTO represents a single attendance response in the output
 type ResponseDTO struct {
-	ResponseID   string        `json:"response_id"`
-	MemberID     string        `json:"member_id"`
-	MemberName   string        `json:"member_name"`   // メンバー表示名
-	TargetDateID string        `json:"target_date_id"` // 対象日ID
-	TargetDate   time.Time     `json:"target_date"`    // 対象日
-	Response     string        `json:"response"`
-	Note         string        `json:"note"`
-	RespondedAt  time.Time     `json:"responded_at"`
+	ResponseID   string    `json:"response_id"`
+	MemberID     string    `json:"member_id"`
+	MemberName   string    `json:"member_name"`    // メンバー表示名
+	TargetDateID string    `json:"target_date_id"` // 対象日ID
+	TargetDate   time.Time `json:"target_date"`    // 対象日
+	Response     string    `json:"response"`
+	Note         string    `json:"note"`
+	RespondedAt  time.Time `json:"responded_at"`
 }
 
 // GetResponsesOutput represents the output for getting all responses for a collection
 type GetResponsesOutput struct {
 	CollectionID string        `json:"collection_id"`
 	Responses    []ResponseDTO `json:"responses"`
+}
+
+// DeleteCollectionInput represents the input for deleting an attendance collection
+type DeleteCollectionInput struct {
+	TenantID     string // from JWT context (管理API)
+	CollectionID string
+}
+
+// DeleteCollectionOutput represents the output for deleting a collection
+type DeleteCollectionOutput struct {
+	CollectionID string     `json:"collection_id"`
+	Status       string     `json:"status"`
+	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }

--- a/backend/internal/app/schedule/delete_schedule_usecase.go
+++ b/backend/internal/app/schedule/delete_schedule_usecase.go
@@ -1,0 +1,51 @@
+package schedule
+
+import (
+	"context"
+
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/schedule"
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/services"
+)
+
+type DeleteScheduleUsecase struct {
+	repo  schedule.DateScheduleRepository
+	clock services.Clock
+}
+
+func NewDeleteScheduleUsecase(repo schedule.DateScheduleRepository, clk services.Clock) *DeleteScheduleUsecase {
+	return &DeleteScheduleUsecase{repo: repo, clock: clk}
+}
+
+func (u *DeleteScheduleUsecase) Execute(ctx context.Context, input DeleteScheduleInput) (*DeleteScheduleOutput, error) {
+	tenantID, err := common.ParseTenantID(input.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduleID, err := common.ParseScheduleID(input.ScheduleID)
+	if err != nil {
+		return nil, err
+	}
+
+	sch, err := u.repo.FindByID(ctx, tenantID, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := u.clock.Now()
+	if err := sch.Delete(now); err != nil {
+		return nil, err
+	}
+
+	if err := u.repo.Save(ctx, sch); err != nil {
+		return nil, err
+	}
+
+	return &DeleteScheduleOutput{
+		ScheduleID: sch.ScheduleID().String(),
+		Status:     sch.Status().String(),
+		DeletedAt:  sch.DeletedAt(),
+		UpdatedAt:  sch.UpdatedAt(),
+	}, nil
+}

--- a/backend/internal/app/schedule/dto.go
+++ b/backend/internal/app/schedule/dto.go
@@ -22,17 +22,17 @@ type CreateScheduleInput struct {
 
 // CreateScheduleOutput represents the output for creating a schedule
 type CreateScheduleOutput struct {
-	ScheduleID string           `json:"schedule_id"`
-	TenantID   string           `json:"tenant_id"`
-	Title      string           `json:"title"`
-	Description string          `json:"description"`
-	EventID    *string          `json:"event_id,omitempty"`
-	PublicToken string          `json:"public_token"`
-	Status     string           `json:"status"`
-	Deadline   *time.Time       `json:"deadline,omitempty"`
-	Candidates []CandidateDTO   `json:"candidates"`
-	CreatedAt  time.Time        `json:"created_at"`
-	UpdatedAt  time.Time        `json:"updated_at"`
+	ScheduleID  string         `json:"schedule_id"`
+	TenantID    string         `json:"tenant_id"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	EventID     *string        `json:"event_id,omitempty"`
+	PublicToken string         `json:"public_token"`
+	Status      string         `json:"status"`
+	Deadline    *time.Time     `json:"deadline,omitempty"`
+	Candidates  []CandidateDTO `json:"candidates"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
 }
 
 // CandidateDTO represents a candidate date in responses
@@ -59,16 +59,16 @@ type ResponseInput struct {
 
 // SubmitResponseOutput represents the output for submitting responses
 type SubmitResponseOutput struct {
-	ScheduleID string    `json:"schedule_id"`
-	MemberID   string    `json:"member_id"`
+	ScheduleID  string    `json:"schedule_id"`
+	MemberID    string    `json:"member_id"`
 	RespondedAt time.Time `json:"responded_at"`
 }
 
 // DecideScheduleInput represents the input for deciding a schedule
 type DecideScheduleInput struct {
-	TenantID     string // from JWT context (管理API)
-	ScheduleID   string
-	CandidateID  string
+	TenantID    string // from JWT context (管理API)
+	ScheduleID  string
+	CandidateID string
 }
 
 // DecideScheduleOutput represents the output for deciding a schedule
@@ -100,19 +100,19 @@ type GetScheduleInput struct {
 
 // GetScheduleOutput represents the output for getting a schedule
 type GetScheduleOutput struct {
-	ScheduleID         string           `json:"schedule_id"`
-	TenantID           string           `json:"tenant_id"`
-	Title              string           `json:"title"`
-	Description        string           `json:"description"`
-	EventID            *string          `json:"event_id,omitempty"`
-	PublicToken        string           `json:"public_token"`
-	Status             string           `json:"status"`
-	Deadline           *time.Time       `json:"deadline,omitempty"`
-	DecidedCandidateID *string          `json:"decided_candidate_id,omitempty"`
-	Candidates         []CandidateDTO   `json:"candidates"`
-	GroupIDs           []string         `json:"group_ids,omitempty"`
-	CreatedAt          time.Time        `json:"created_at"`
-	UpdatedAt          time.Time        `json:"updated_at"`
+	ScheduleID         string         `json:"schedule_id"`
+	TenantID           string         `json:"tenant_id"`
+	Title              string         `json:"title"`
+	Description        string         `json:"description"`
+	EventID            *string        `json:"event_id,omitempty"`
+	PublicToken        string         `json:"public_token"`
+	Status             string         `json:"status"`
+	Deadline           *time.Time     `json:"deadline,omitempty"`
+	DecidedCandidateID *string        `json:"decided_candidate_id,omitempty"`
+	Candidates         []CandidateDTO `json:"candidates"`
+	GroupIDs           []string       `json:"group_ids,omitempty"`
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
 }
 
 // GetResponsesInput represents the input for getting responses
@@ -135,4 +135,18 @@ type ScheduleResponseDTO struct {
 type GetResponsesOutput struct {
 	ScheduleID string                `json:"schedule_id"`
 	Responses  []ScheduleResponseDTO `json:"responses"`
+}
+
+// DeleteScheduleInput represents the input for deleting a schedule
+type DeleteScheduleInput struct {
+	TenantID   string // from JWT context (管理API)
+	ScheduleID string
+}
+
+// DeleteScheduleOutput represents the output for deleting a schedule
+type DeleteScheduleOutput struct {
+	ScheduleID string     `json:"schedule_id"`
+	Status     string     `json:"status"`
+	DeletedAt  *time.Time `json:"deleted_at,omitempty"`
+	UpdatedAt  time.Time  `json:"updated_at"`
 }

--- a/backend/internal/app/schedule/schedule_usecase_test.go
+++ b/backend/internal/app/schedule/schedule_usecase_test.go
@@ -17,14 +17,14 @@ import (
 
 // MockDateScheduleRepository is a mock implementation of schedule.DateScheduleRepository
 type MockDateScheduleRepository struct {
-	saveFunc                        func(ctx context.Context, sch *schedule.DateSchedule) error
-	findByIDFunc                    func(ctx context.Context, tenantID common.TenantID, id common.ScheduleID) (*schedule.DateSchedule, error)
-	findByTokenFunc                 func(ctx context.Context, token common.PublicToken) (*schedule.DateSchedule, error)
-	findByTenantIDFunc              func(ctx context.Context, tenantID common.TenantID) ([]*schedule.DateSchedule, error)
-	upsertResponseFunc              func(ctx context.Context, response *schedule.DateScheduleResponse) error
-	findResponsesByScheduleIDFunc   func(ctx context.Context, scheduleID common.ScheduleID) ([]*schedule.DateScheduleResponse, error)
-	findCandidatesByScheduleIDFunc  func(ctx context.Context, scheduleID common.ScheduleID) ([]*schedule.CandidateDate, error)
-	saveGroupAssignmentsFunc        func(ctx context.Context, scheduleID common.ScheduleID, assignments []*schedule.ScheduleGroupAssignment) error
+	saveFunc                             func(ctx context.Context, sch *schedule.DateSchedule) error
+	findByIDFunc                         func(ctx context.Context, tenantID common.TenantID, id common.ScheduleID) (*schedule.DateSchedule, error)
+	findByTokenFunc                      func(ctx context.Context, token common.PublicToken) (*schedule.DateSchedule, error)
+	findByTenantIDFunc                   func(ctx context.Context, tenantID common.TenantID) ([]*schedule.DateSchedule, error)
+	upsertResponseFunc                   func(ctx context.Context, response *schedule.DateScheduleResponse) error
+	findResponsesByScheduleIDFunc        func(ctx context.Context, scheduleID common.ScheduleID) ([]*schedule.DateScheduleResponse, error)
+	findCandidatesByScheduleIDFunc       func(ctx context.Context, scheduleID common.ScheduleID) ([]*schedule.CandidateDate, error)
+	saveGroupAssignmentsFunc             func(ctx context.Context, scheduleID common.ScheduleID, assignments []*schedule.ScheduleGroupAssignment) error
 	findGroupAssignmentsByScheduleIDFunc func(ctx context.Context, scheduleID common.ScheduleID) ([]*schedule.ScheduleGroupAssignment, error)
 }
 

--- a/backend/internal/domain/attendance/collection.go
+++ b/backend/internal/domain/attendance/collection.go
@@ -147,6 +147,17 @@ func (c *AttendanceCollection) Close(now time.Time) error {
 	return nil
 }
 
+// Delete はコレクションを削除済みにする（ソフトデリート）
+// now は App層から Clock 経由で渡される（Domain層で time.Now() を呼ばない）
+func (c *AttendanceCollection) Delete(now time.Time) error {
+	if c.deletedAt != nil {
+		return ErrAlreadyDeleted
+	}
+	c.deletedAt = &now
+	c.updatedAt = now
+	return nil
+}
+
 // Getters
 
 func (c *AttendanceCollection) CollectionID() common.CollectionID {

--- a/backend/internal/domain/attendance/errors.go
+++ b/backend/internal/domain/attendance/errors.go
@@ -1,6 +1,8 @@
 package attendance
 
-import "github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+import (
+	"github.com/erenoa/vrc-shift-scheduler/backend/internal/domain/common"
+)
 
 var (
 	// ErrCollectionClosed is returned when trying to respond to a closed collection
@@ -11,4 +13,7 @@ var (
 
 	// ErrAlreadyClosed is returned when trying to close an already closed collection
 	ErrAlreadyClosed = common.NewInvariantViolationError("collection is already closed")
+
+	// ErrAlreadyDeleted is returned when trying to delete an already deleted collection
+	ErrAlreadyDeleted = common.NewInvariantViolationError("collection is already deleted")
 )

--- a/backend/internal/domain/schedule/errors.go
+++ b/backend/internal/domain/schedule/errors.go
@@ -17,4 +17,7 @@ var (
 
 	// ErrCandidateNotFound is returned when the specified candidate is not found
 	ErrCandidateNotFound = errors.New("candidate not found")
+
+	// ErrAlreadyDeleted is returned when trying to delete an already deleted schedule
+	ErrAlreadyDeleted = errors.New("schedule is already deleted")
 )

--- a/backend/internal/domain/schedule/schedule.go
+++ b/backend/internal/domain/schedule/schedule.go
@@ -10,19 +10,19 @@ import (
 // MVP方針: responses は集約内で保持しない（Repository側UPSERTで管理）
 // candidates は集約内で保持する（作成時に確定）
 type DateSchedule struct {
-	scheduleID          common.ScheduleID
-	tenantID            common.TenantID
-	title               string
-	description         string
-	eventID             *common.EventID
-	publicToken         common.PublicToken
-	status              Status
-	deadline            *time.Time
-	decidedCandidateID  *common.CandidateID
-	candidates          []*CandidateDate // 候補日は集約内で保持
-	createdAt           time.Time
-	updatedAt           time.Time
-	deletedAt           *time.Time
+	scheduleID         common.ScheduleID
+	tenantID           common.TenantID
+	title              string
+	description        string
+	eventID            *common.EventID
+	publicToken        common.PublicToken
+	status             Status
+	deadline           *time.Time
+	decidedCandidateID *common.CandidateID
+	candidates         []*CandidateDate // 候補日は集約内で保持
+	createdAt          time.Time
+	updatedAt          time.Time
+	deletedAt          *time.Time
 }
 
 // NewDateSchedule creates a new DateSchedule entity
@@ -173,6 +173,17 @@ func (s *DateSchedule) Close(now time.Time) error {
 		return ErrAlreadyClosed
 	}
 	s.status = StatusClosed
+	s.updatedAt = now
+	return nil
+}
+
+// Delete はスケジュールを削除済みにする（ソフトデリート）
+// now は App層から Clock 経由で渡される（Domain層で time.Now() を呼ばない）
+func (s *DateSchedule) Delete(now time.Time) error {
+	if s.deletedAt != nil {
+		return ErrAlreadyDeleted
+	}
+	s.deletedAt = &now
 	s.updatedAt = now
 	return nil
 }

--- a/backend/internal/interface/rest/attendance_handler.go
+++ b/backend/internal/interface/rest/attendance_handler.go
@@ -13,13 +13,14 @@ import (
 
 // AttendanceHandler handles attendance-related HTTP requests
 type AttendanceHandler struct {
-	createCollectionUsecase       *attendance.CreateCollectionUsecase
-	submitResponseUsecase         *attendance.SubmitResponseUsecase
-	closeCollectionUsecase        *attendance.CloseCollectionUsecase
-	getCollectionUsecase          *attendance.GetCollectionUsecase
-	getCollectionByTokenUsecase   *attendance.GetCollectionByTokenUsecase
-	getResponsesUsecase           *attendance.GetResponsesUsecase
-	listCollectionsUsecase        *attendance.ListCollectionsUsecase
+	createCollectionUsecase     *attendance.CreateCollectionUsecase
+	submitResponseUsecase       *attendance.SubmitResponseUsecase
+	closeCollectionUsecase      *attendance.CloseCollectionUsecase
+	deleteCollectionUsecase     *attendance.DeleteCollectionUsecase
+	getCollectionUsecase        *attendance.GetCollectionUsecase
+	getCollectionByTokenUsecase *attendance.GetCollectionByTokenUsecase
+	getResponsesUsecase         *attendance.GetResponsesUsecase
+	listCollectionsUsecase      *attendance.ListCollectionsUsecase
 }
 
 // NewAttendanceHandler creates a new AttendanceHandler with injected usecases
@@ -27,19 +28,21 @@ func NewAttendanceHandler(
 	createCollectionUC *attendance.CreateCollectionUsecase,
 	submitResponseUC *attendance.SubmitResponseUsecase,
 	closeCollectionUC *attendance.CloseCollectionUsecase,
+	deleteCollectionUC *attendance.DeleteCollectionUsecase,
 	getCollectionUC *attendance.GetCollectionUsecase,
 	getCollectionByTokenUC *attendance.GetCollectionByTokenUsecase,
 	getResponsesUC *attendance.GetResponsesUsecase,
 	listCollectionsUC *attendance.ListCollectionsUsecase,
 ) *AttendanceHandler {
 	return &AttendanceHandler{
-		createCollectionUsecase:       createCollectionUC,
-		submitResponseUsecase:         submitResponseUC,
-		closeCollectionUsecase:        closeCollectionUC,
-		getCollectionUsecase:          getCollectionUC,
-		getCollectionByTokenUsecase:   getCollectionByTokenUC,
-		getResponsesUsecase:           getResponsesUC,
-		listCollectionsUsecase:        listCollectionsUC,
+		createCollectionUsecase:     createCollectionUC,
+		submitResponseUsecase:       submitResponseUC,
+		closeCollectionUsecase:      closeCollectionUC,
+		deleteCollectionUsecase:     deleteCollectionUC,
+		getCollectionUsecase:        getCollectionUC,
+		getCollectionByTokenUsecase: getCollectionByTokenUC,
+		getResponsesUsecase:         getResponsesUC,
+		listCollectionsUsecase:      listCollectionsUC,
 	}
 }
 
@@ -57,25 +60,25 @@ type CreateCollectionRequest struct {
 // TargetDateResponse represents a target date in API responses
 type TargetDateResponse struct {
 	TargetDateID string `json:"target_date_id"`
-	TargetDate   string `json:"target_date"`   // ISO 8601 format
+	TargetDate   string `json:"target_date"` // ISO 8601 format
 	DisplayOrder int    `json:"display_order"`
 }
 
 // CollectionResponse represents an attendance collection in API responses
 type CollectionResponse struct {
-	CollectionID string                `json:"collection_id"`
-	TenantID     string                `json:"tenant_id"`
-	Title        string                `json:"title"`
-	Description  string                `json:"description"`
-	TargetType   string                `json:"target_type"`
-	TargetID     string                `json:"target_id"`
-	TargetDates  []TargetDateResponse  `json:"target_dates,omitempty"` // Target dates with IDs
-	PublicToken  string                `json:"public_token"`
-	Status       string                `json:"status"`
-	Deadline     *time.Time            `json:"deadline,omitempty"`
-	GroupIDs     []string              `json:"group_ids,omitempty"`    // Target group IDs
-	CreatedAt    time.Time             `json:"created_at"`
-	UpdatedAt    time.Time             `json:"updated_at"`
+	CollectionID string               `json:"collection_id"`
+	TenantID     string               `json:"tenant_id"`
+	Title        string               `json:"title"`
+	Description  string               `json:"description"`
+	TargetType   string               `json:"target_type"`
+	TargetID     string               `json:"target_id"`
+	TargetDates  []TargetDateResponse `json:"target_dates,omitempty"` // Target dates with IDs
+	PublicToken  string               `json:"public_token"`
+	Status       string               `json:"status"`
+	Deadline     *time.Time           `json:"deadline,omitempty"`
+	GroupIDs     []string             `json:"group_ids,omitempty"` // Target group IDs
+	CreatedAt    time.Time            `json:"created_at"`
+	UpdatedAt    time.Time            `json:"updated_at"`
 }
 
 // SubmitResponseRequest represents the request body for submitting an attendance response
@@ -284,6 +287,49 @@ func (h *AttendanceHandler) CloseCollection(w http.ResponseWriter, r *http.Reque
 		Data: map[string]interface{}{
 			"collection_id": output.CollectionID,
 			"status":        output.Status,
+			"updated_at":    output.UpdatedAt,
+		},
+	})
+}
+
+// DeleteCollection handles DELETE /api/v1/attendance/collections/:id
+func (h *AttendanceHandler) DeleteCollection(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// TenantIDの取得（JWTから）
+	tenantID, ok := GetTenantID(ctx)
+	if !ok {
+		RespondBadRequest(w, "tenant_id is required")
+		return
+	}
+
+	// URLパラメータからcollection_idを取得
+	collectionID := chi.URLParam(r, "collection_id")
+	if collectionID == "" {
+		RespondBadRequest(w, "collection_id is required")
+		return
+	}
+
+	// Usecase呼び出し
+	output, err := h.deleteCollectionUsecase.Execute(ctx, attendance.DeleteCollectionInput{
+		TenantID:     tenantID.String(),
+		CollectionID: collectionID,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domainAttendance.ErrAlreadyDeleted):
+			RespondConflict(w, "Collection is already deleted")
+		default:
+			RespondDomainError(w, err)
+		}
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, SuccessResponse{
+		Data: map[string]interface{}{
+			"collection_id": output.CollectionID,
+			"status":        output.Status,
+			"deleted_at":    output.DeletedAt,
 			"updated_at":    output.UpdatedAt,
 		},
 	})

--- a/backend/internal/interface/rest/router.go
+++ b/backend/internal/interface/rest/router.go
@@ -175,6 +175,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			appattendance.NewCreateCollectionUsecase(attendanceRepo, systemClock),
 			appattendance.NewSubmitResponseUsecase(attendanceRepo, txManager, systemClock),
 			appattendance.NewCloseCollectionUsecase(attendanceRepo, systemClock),
+			appattendance.NewDeleteCollectionUsecase(attendanceRepo, systemClock),
 			appattendance.NewGetCollectionUsecase(attendanceRepo),
 			appattendance.NewGetCollectionByTokenUsecase(attendanceRepo),
 			appattendance.NewGetResponsesUsecase(attendanceRepo, memberRepo),
@@ -322,6 +323,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateAttendance)).Post("/", attendanceHandler.CreateCollection)
 			r.Get("/{collection_id}", attendanceHandler.GetCollection)
 			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateAttendance)).Post("/{collection_id}/close", attendanceHandler.CloseCollection)
+			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateAttendance)).Delete("/{collection_id}", attendanceHandler.DeleteCollection)
 			r.Get("/{collection_id}/responses", attendanceHandler.GetResponses)
 		})
 
@@ -332,6 +334,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			appschedule.NewSubmitResponseUsecase(scheduleRepo, txManager, systemClock),
 			appschedule.NewDecideScheduleUsecase(scheduleRepo, systemClock),
 			appschedule.NewCloseScheduleUsecase(scheduleRepo, systemClock),
+			appschedule.NewDeleteScheduleUsecase(scheduleRepo, systemClock),
 			appschedule.NewGetScheduleUsecase(scheduleRepo),
 			appschedule.NewGetScheduleByTokenUsecase(scheduleRepo),
 			appschedule.NewGetResponsesUsecase(scheduleRepo),
@@ -343,6 +346,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			r.Get("/{schedule_id}", scheduleHandler.GetSchedule)
 			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateSchedule)).Post("/{schedule_id}/decide", scheduleHandler.DecideSchedule)
 			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateSchedule)).Post("/{schedule_id}/close", scheduleHandler.CloseSchedule)
+			r.With(permissionChecker.RequirePermission(tenant.PermissionCreateSchedule)).Delete("/{schedule_id}", scheduleHandler.DeleteSchedule)
 			r.Get("/{schedule_id}/responses", scheduleHandler.GetResponses)
 		})
 
@@ -455,6 +459,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			appattendance.NewCreateCollectionUsecase(publicAttendanceRepoForHandler, publicClock),
 			appattendance.NewSubmitResponseUsecase(publicAttendanceRepoForHandler, publicTxManager, publicClock),
 			appattendance.NewCloseCollectionUsecase(publicAttendanceRepoForHandler, publicClock),
+			appattendance.NewDeleteCollectionUsecase(publicAttendanceRepoForHandler, publicClock),
 			appattendance.NewGetCollectionUsecase(publicAttendanceRepoForHandler),
 			appattendance.NewGetCollectionByTokenUsecase(publicAttendanceRepoForHandler),
 			appattendance.NewGetResponsesUsecase(publicAttendanceRepoForHandler, publicMemberRepoForAttendance),
@@ -471,6 +476,7 @@ func NewRouter(dbPool *pgxpool.Pool) http.Handler {
 			appschedule.NewSubmitResponseUsecase(publicScheduleRepo, publicTxManager, publicClock),
 			appschedule.NewDecideScheduleUsecase(publicScheduleRepo, publicClock),
 			appschedule.NewCloseScheduleUsecase(publicScheduleRepo, publicClock),
+			appschedule.NewDeleteScheduleUsecase(publicScheduleRepo, publicClock),
 			appschedule.NewGetScheduleUsecase(publicScheduleRepo),
 			appschedule.NewGetScheduleByTokenUsecase(publicScheduleRepo),
 			appschedule.NewGetResponsesUsecase(publicScheduleRepo),


### PR DESCRIPTION
## 概要
Schedule および Attendance Collection に削除（ソフトデリート）機能を追加しました。

## 変更内容
- Domain層
  - Schedule / Collection エンティティに Delete(now) を追加（ソフトデリート）
- Application層
  - DeleteScheduleUsecase
  - DeleteCollectionUsecase を新規作成
- Interface層
  - 管理API向けに DELETE ハンドラを追加
- Router
  - 管理APIに DELETE エンドポイントを追加

## 補足
- 削除は物理削除ではなく、deleted_at を設定するソフトデリートです
- 既に削除済みの場合はエラーを返す仕様です
- go build ./... が通ることを確認しています


