### PR TITLE
fix: R2バックアップスクリプトをリポジトリに追加

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,74 +1,176 @@
 #!/bin/bash
 # VRC Shift Scheduler - Database Backup Script
 # Backs up PostgreSQL database to Cloudflare R2
-# Run via cron: 0 4 * * * /opt/vrcshift/scripts/backup-db.sh >> /var/log/db-backup.log 2>&1
+#
+# Setup Requirements:
+#   1. AWS CLI installed: apt install awscli
+#   2. AWS credentials configured in ~/.aws/credentials:
+#      [default]
+#      aws_access_key_id = <R2_ACCESS_KEY_ID>
+#      aws_secret_access_key = <R2_SECRET_ACCESS_KEY>
+#   3. AWS config in ~/.aws/config:
+#      [default]
+#      region = auto
+#   4. Environment variable R2_ENDPOINT set (or use default)
+#
+# Cron setup:
+#   0 4 * * * /opt/vrcshift/scripts/backup-db.sh >> /var/log/db-backup.log 2>&1
 
-set -e
+set -euo pipefail
 
-# Configuration
-BACKUP_DIR="/tmp/db-backups"
+# Configuration (can be overridden by environment variables)
+BACKUP_DIR="${BACKUP_DIR:-/tmp/db-backups}"
+R2_BUCKET="${R2_BUCKET:-eventshift-db-backup}"
+R2_ENDPOINT="${R2_ENDPOINT:-https://80dac8172d46968cd0d2da338cbe7598.r2.cloudflarestorage.com}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+DB_CONTAINER="${DB_CONTAINER:-vrc-shift-db}"
+DB_USER="${DB_USER:-vrcshift}"
+DB_NAME="${DB_NAME:-vrcshift}"
+MIN_BACKUP_SIZE="${MIN_BACKUP_SIZE:-1024}"  # Minimum expected backup size in bytes
+
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="vrcshift_backup_${TIMESTAMP}.sql.gz"
-R2_BUCKET="eventshift-db-backup"
-R2_ENDPOINT="https://80dac8172d46968cd0d2da338cbe7598.r2.cloudflarestorage.com"
-RETENTION_DAYS=30
 
-# Docker container name
-DB_CONTAINER="vrc-shift-db"
-DB_USER="vrcshift"
-DB_NAME="vrcshift"
+# Pre-flight checks
+preflight_check() {
+    local errors=0
 
-# Create backup directory
-mkdir -p "$BACKUP_DIR"
+    # Check AWS CLI
+    if ! command -v aws &> /dev/null; then
+        echo "[$(date)] ERROR: AWS CLI is not installed"
+        errors=$((errors + 1))
+    fi
 
-echo "[$(date)] Starting database backup..."
+    # Check Docker
+    if ! command -v docker &> /dev/null; then
+        echo "[$(date)] ERROR: Docker is not installed"
+        errors=$((errors + 1))
+    fi
 
-# Create database dump and compress
-docker exec "$DB_CONTAINER" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_DIR/$BACKUP_FILE"
+    # Check if DB container is running
+    if ! docker ps --format '{{.Names}}' | grep -q "^${DB_CONTAINER}$"; then
+        echo "[$(date)] ERROR: Database container '${DB_CONTAINER}' is not running"
+        errors=$((errors + 1))
+    fi
 
-# Check if backup was created successfully
-if [ -f "$BACKUP_DIR/$BACKUP_FILE" ]; then
-    BACKUP_SIZE=$(du -h "$BACKUP_DIR/$BACKUP_FILE" | cut -f1)
-    echo "[$(date)] Backup created: $BACKUP_FILE ($BACKUP_SIZE)"
-else
-    echo "[$(date)] ERROR: Backup file not created"
-    exit 1
-fi
+    # Check AWS credentials
+    if ! aws sts get-caller-identity --endpoint-url "$R2_ENDPOINT" &> /dev/null 2>&1; then
+        # R2 doesn't support STS, so just check if credentials file exists
+        if [ ! -f ~/.aws/credentials ]; then
+            echo "[$(date)] ERROR: AWS credentials not configured (~/.aws/credentials not found)"
+            errors=$((errors + 1))
+        fi
+    fi
 
-# Upload to R2 using AWS CLI (S3-compatible)
-echo "[$(date)] Uploading to R2..."
-aws s3 cp "$BACKUP_DIR/$BACKUP_FILE" "s3://$R2_BUCKET/$BACKUP_FILE" \
-    --endpoint-url "$R2_ENDPOINT"
+    if [ $errors -gt 0 ]; then
+        echo "[$(date)] Pre-flight check failed with $errors error(s)"
+        exit 1
+    fi
 
-if [ $? -eq 0 ]; then
+    echo "[$(date)] Pre-flight checks passed"
+}
+
+# Create backup
+create_backup() {
+    mkdir -p "$BACKUP_DIR"
+
+    echo "[$(date)] Starting database backup..."
+
+    # Create database dump and compress
+    if ! docker exec "$DB_CONTAINER" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_DIR/$BACKUP_FILE"; then
+        echo "[$(date)] ERROR: Failed to create database dump"
+        exit 1
+    fi
+
+    # Verify backup was created and has minimum size
+    if [ ! -f "$BACKUP_DIR/$BACKUP_FILE" ]; then
+        echo "[$(date)] ERROR: Backup file not created"
+        exit 1
+    fi
+
+    local backup_size
+    backup_size=$(stat -c%s "$BACKUP_DIR/$BACKUP_FILE" 2>/dev/null || stat -f%z "$BACKUP_DIR/$BACKUP_FILE" 2>/dev/null)
+
+    if [ "$backup_size" -lt "$MIN_BACKUP_SIZE" ]; then
+        echo "[$(date)] ERROR: Backup file too small (${backup_size} bytes), possibly corrupted"
+        rm -f "$BACKUP_DIR/$BACKUP_FILE"
+        exit 1
+    fi
+
+    local backup_size_human
+    backup_size_human=$(du -h "$BACKUP_DIR/$BACKUP_FILE" | cut -f1)
+    echo "[$(date)] Backup created: $BACKUP_FILE ($backup_size_human)"
+}
+
+# Upload to R2
+upload_backup() {
+    echo "[$(date)] Uploading to R2..."
+
+    if ! aws s3 cp "$BACKUP_DIR/$BACKUP_FILE" "s3://$R2_BUCKET/$BACKUP_FILE" \
+        --endpoint-url "$R2_ENDPOINT"; then
+        echo "[$(date)] ERROR: Upload failed"
+        exit 1
+    fi
+
     echo "[$(date)] Upload successful"
-else
-    echo "[$(date)] ERROR: Upload failed"
-    exit 1
-fi
+}
 
-# Clean up old backups (keep last RETENTION_DAYS days)
-echo "[$(date)] Cleaning up old backups..."
+# Clean up old backups
+cleanup_old_backups() {
+    echo "[$(date)] Cleaning up old backups..."
 
-# Delete old files from R2
-aws s3 ls "s3://$R2_BUCKET/" --endpoint-url "$R2_ENDPOINT" | while read -r line; do
-    file_date=$(echo "$line" | awk '{print $1}')
-    file_name=$(echo "$line" | awk '{print $4}')
+    local current_timestamp
+    current_timestamp=$(date +%s)
+    local cleanup_errors=0
 
-    if [ -n "$file_name" ]; then
-        # Calculate age in days
-        file_timestamp=$(date -d "$file_date" +%s 2>/dev/null || echo "0")
-        current_timestamp=$(date +%s)
+    # Get list of files and process
+    aws s3 ls "s3://$R2_BUCKET/" --endpoint-url "$R2_ENDPOINT" 2>/dev/null | while read -r line; do
+        local file_date file_name
+        file_date=$(echo "$line" | awk '{print $1}')
+        file_name=$(echo "$line" | awk '{print $4}')
+
+        if [ -z "$file_name" ]; then
+            continue
+        fi
+
+        # Parse date and calculate age
+        local file_timestamp
+        file_timestamp=$(date -d "$file_date" +%s 2>/dev/null) || {
+            echo "[$(date)] WARNING: Could not parse date for $file_name, skipping"
+            continue
+        }
+
+        local age_days
         age_days=$(( (current_timestamp - file_timestamp) / 86400 ))
 
         if [ "$age_days" -gt "$RETENTION_DAYS" ]; then
             echo "[$(date)] Deleting old backup: $file_name (${age_days} days old)"
-            aws s3 rm "s3://$R2_BUCKET/$file_name" --endpoint-url "$R2_ENDPOINT"
+            if ! aws s3 rm "s3://$R2_BUCKET/$file_name" --endpoint-url "$R2_ENDPOINT" 2>/dev/null; then
+                echo "[$(date)] WARNING: Failed to delete $file_name"
+                cleanup_errors=$((cleanup_errors + 1))
+            fi
         fi
+    done
+
+    if [ $cleanup_errors -gt 0 ]; then
+        echo "[$(date)] WARNING: $cleanup_errors file(s) failed to delete during cleanup"
     fi
-done
+}
 
-# Clean up local backup file
-rm -f "$BACKUP_DIR/$BACKUP_FILE"
+# Clean up local files
+cleanup_local() {
+    rm -f "$BACKUP_DIR/$BACKUP_FILE"
+}
 
-echo "[$(date)] Backup completed successfully"
+# Main execution
+main() {
+    preflight_check
+    create_backup
+    upload_backup
+    cleanup_old_backups
+    cleanup_local
+
+    echo "[$(date)] Backup completed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- デプロイ時に `/opt/vrcshift` が削除されて `backup-db.sh` が消失し、バックアップが停止していた問題を修正
- `scripts/backup-db.sh` をリポジトリに追加し、今後のデプロイでも保持されるようにした

## 原因
12月23日のデプロイ後、`/opt/vrcshift/scripts/backup-db.sh` が削除され、cronジョブが `not found` エラーを出力し続けていた

## 修正内容
- `scripts/backup-db.sh` を新規追加
- 毎日4時にcronで実行（30日間保持）
- Cloudflare R2にアップロード

## 動作確認
サーバー上で手動実行して正常動作を確認済み:
```
[Mon Jan  5 10:08:09 PM JST 2026] Backup created: vrcshift_backup_20260105_220809.sql.gz (32K)
[Mon Jan  5 10:08:11 PM JST 2026] Upload successful
[Mon Jan  5 10:08:13 PM JST 2026] Backup completed successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)