### PR TITLE
feat: お知らせベルのUI改善 - タイトル一覧から展開表示に変更

### DIFF
--- a/web-frontend/src/components/AnnouncementBell.tsx
+++ b/web-frontend/src/components/AnnouncementBell.tsx
@@ -93,6 +93,13 @@ export function AnnouncementBell() {
     }
   }
 
+  function handleKeyDown(event: React.KeyboardEvent, announcement: Announcement) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleAnnouncementClick(announcement);
+    }
+  }
+
   return (
     <div className="relative" ref={dropdownRef}>
       <button
@@ -133,8 +140,12 @@ export function AnnouncementBell() {
                 return (
                   <div
                     key={announcement.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={isExpanded}
                     onClick={() => handleAnnouncementClick(announcement)}
-                    className={`p-3 border-b border-gray-100 cursor-pointer hover:bg-gray-50 ${
+                    onKeyDown={(e) => handleKeyDown(e, announcement)}
+                    className={`p-3 border-b border-gray-100 cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset ${
                       !announcement.is_read ? 'bg-blue-50' : ''
                     }`}
                   >


### PR DESCRIPTION
## Summary
- デフォルトではお知らせのタイトルと日付のみ表示
- タイトルをクリックすると本文を展開表示
- 展開時に未読のお知らせを自動で既読に変更
- 展開/折りたたみ状態を矢印アイコン（↓）で視覚的に表示

## 変更内容
- `expandedId` stateを追加して現在展開中のお知らせを管理
- `handleAnnouncementClick` 関数を追加して展開/折りたたみと既読処理を統合
- 本文は `isExpanded` 状態の場合のみ表示

## Test plan
- [ ] お知らせベルをクリックしてドロップダウンが開く
- [ ] タイトルと日付のみが一覧表示される（本文は非表示）
- [ ] タイトルをクリックすると本文が展開される
- [ ] 再度クリックすると折りたたまれる
- [ ] 未読のお知らせを展開すると既読になる
- [ ] 矢印アイコンが展開状態に応じて回転する

🤖 Generated with [Claude Code](https://claude.com/claude-code)