### PR TITLE
fix: メンバー0人時にシフト割り当て画面が真っ白になる問題を修正

### DIFF
--- a/web-frontend/src/pages/AssignShift.tsx
+++ b/web-frontend/src/pages/AssignShift.tsx
@@ -531,11 +531,16 @@ export default function AssignShift() {
           </div>
         )}
 
-        {/* メンバーが0人の場合の警告表示 */}
-        {members.length === 0 && !loading && (
+        {success ? (
+          <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
+            <p className="text-green-800 font-bold mb-2">✅ {success}</p>
+            <p className="text-sm text-green-700">シフト枠一覧に戻っています...</p>
+          </div>
+        ) : members.length === 0 ? (
+          /* メンバーが0人の場合の警告表示 */
           <div className="bg-yellow-50 border border-yellow-300 rounded-lg p-6 mb-6 text-center">
             <div className="text-yellow-600 mb-3">
-              <svg className="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
@@ -547,20 +552,13 @@ export default function AssignShift() {
               to="/members"
               className="inline-flex items-center px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 transition-colors"
             >
-              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
               </svg>
               メンバーを登録する
             </Link>
           </div>
-        )}
-
-        {success ? (
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
-            <p className="text-green-800 font-bold mb-2">✅ {success}</p>
-            <p className="text-sm text-green-700">シフト枠一覧に戻っています...</p>
-          </div>
-        ) : members.length === 0 ? null : (
+        ) : (
           <form onSubmit={handleSubmit}>
             <div className="mb-6">
               <label className="label">


### PR DESCRIPTION
## Summary
- メンバーが0人の場合、シフト割り当て画面が真っ白になる問題を修正
- 警告メッセージとメンバー登録ページへのリンクを表示するように変更
- フォームはメンバーがいる場合のみ表示

## Test plan
- [ ] メンバーが0人の状態でシフト割り当て画面を開く
- [ ] 警告メッセージが表示されることを確認
- [ ] 「メンバーを登録する」ボタンをクリックしてメンバー一覧に遷移することを確認
- [ ] メンバーがいる状態では通常通りフォームが表示されることを確認

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)