### PR TITLE
feat: [Frontend] 日程調整・出欠確認の削除機能を追加

### DIFF
--- a/web-frontend/src/lib/api/attendanceApi.ts
+++ b/web-frontend/src/lib/api/attendanceApi.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '../../types/api';
+import { apiClient } from '../apiClient';
 
 /**
  * 対象日入力（リクエスト用）
@@ -192,29 +193,8 @@ export async function closeAttendanceCollection(collectionId: string): Promise<v
  * 成功時: 204 No Content（レスポンスボディなし）
  */
 export async function deleteAttendanceCollection(collectionId: string): Promise<void> {
-  const baseURL = import.meta.env.VITE_API_BASE_URL || '';
-  const token = localStorage.getItem('auth_token');
-
-  if (!token) {
-    throw new Error('認証が必要です。ログインしてください。');
-  }
-
-  const response = await fetch(
-    `${baseURL}/api/v1/attendance/collections/${collectionId}`,
-    {
-      method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-      },
-    }
-  );
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`出欠確認の削除に失敗しました: ${text || response.statusText}`);
-  }
+  await apiClient.delete(`/api/v1/attendance/collections/${collectionId}`);
 }
-
 
 /**
  * 出欠回答一覧を取得

--- a/web-frontend/src/lib/api/scheduleApi.ts
+++ b/web-frontend/src/lib/api/scheduleApi.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '../../types/api';
+import { apiClient } from '../apiClient';
 
 /**
  * 候補日
@@ -192,26 +193,8 @@ export async function closeSchedule(scheduleId: string): Promise<void> {
  * 成功時: 204 No Content（レスポンスボディなし）
  */
 export async function deleteSchedule(scheduleId: string): Promise<void> {
-  const baseURL = import.meta.env.VITE_API_BASE_URL || '';
-  const token = localStorage.getItem('auth_token');
-
-  if (!token) {
-    throw new Error('認証が必要です。ログインしてください。');
-  }
-
-  const response = await fetch(`${baseURL}/api/v1/schedules/${scheduleId}`, {
-    method: 'DELETE',
-    headers: {
-      'Authorization': `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`日程調整の削除に失敗しました: ${text || response.statusText}`);
-  }
+  await apiClient.delete(`/api/v1/schedules/${scheduleId}`);
 }
-
 
 /**
  * 日程回答一覧を取得

--- a/web-frontend/src/pages/AttendanceDetail.tsx
+++ b/web-frontend/src/pages/AttendanceDetail.tsx
@@ -11,6 +11,7 @@ import {
 import { getMembers } from '../lib/api';
 import { getMemberGroups, getMemberGroupDetail, type MemberGroup } from '../lib/api/memberGroupApi';
 import { listRoles, type Role } from '../lib/api/roleApi';
+import { ApiClientError } from '../lib/apiClient';
 import type { Member } from '../types/api';
 
 // ソートの種類
@@ -160,7 +161,11 @@ export default function AttendanceDetail() {
       alert('出欠確認を削除しました');
       navigate('/attendance');
     } catch (err) {
-      alert(err instanceof Error ? err.message : '削除に失敗しました');
+      if (err instanceof ApiClientError) {
+        alert(err.getUserMessage());
+      } else {
+        alert(err instanceof Error ? err.message : '削除に失敗しました');
+      }
     } finally {
       setDeleting(false);
     }

--- a/web-frontend/src/pages/ScheduleDetail.tsx
+++ b/web-frontend/src/pages/ScheduleDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { getSchedule, getScheduleResponses, deleteSchedule, type Schedule, type ScheduleResponse } from '../lib/api/scheduleApi';
 import { getMembers } from '../lib/api';
 import { getMemberGroups, getMemberGroupDetail, type MemberGroup } from '../lib/api/memberGroupApi';
+import { ApiClientError } from '../lib/apiClient';
 import type { Member } from '../types/api';
 
 interface Candidate {
@@ -104,12 +105,15 @@ export default function ScheduleDetail() {
       alert('日程調整を削除しました');
       navigate('/schedules');
     } catch (err) {
-      alert(err instanceof Error ? err.message : '削除に失敗しました');
+      if (err instanceof ApiClientError) {
+        alert(err.getUserMessage());
+      } else {
+        alert(err instanceof Error ? err.message : '削除に失敗しました');
+      }
     } finally {
       setDeleting(false);
     }
   };
-
 
   const handleCopy = async () => {
     try {


### PR DESCRIPTION
Issue #37 対応です。

日程調整および出欠確認の詳細ページに削除ボタンを追加しました。
削除時は確認ダイアログを表示し、削除成功後は一覧ページへ遷移します。

実装内容
- ScheduleDetail / AttendanceDetail に削除ボタン(赤色、ステータスバッジ横)を追加
- 削除中はボタンを disabled にし、連続操作を防止
- DELETE API 呼び出し後、一覧画面へリダイレクト

確認内容
- Docker（Node 20）環境でフロントエンドの production build が通ることを確認
- ログイン制約のある環境のため、UI 表示および API 呼び出しまでを確認

補足
- develop 取り込み時のコンフリクトは、機能が独立しているため両方の実装を残す形で解消しています。