### PR TITLE
feat: 出欠締め切りに「その日の23:59」を簡単設定できるUIを追加 (#152)

### DIFF
--- a/web-frontend/src/pages/AttendanceList.tsx
+++ b/web-frontend/src/pages/AttendanceList.tsx
@@ -630,6 +630,8 @@ export default function AttendanceList() {
                   onChange={(e) => {
                     if (e.target.value) {
                       setDeadline(`${e.target.value}T23:59`);
+                    } else {
+                      setDeadline('');
                     }
                   }}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-accent"


### PR DESCRIPTION
## Summary
- 出欠確認の締め切り設定で、日付を選択するだけで「その日の23:59」を自動設定できるUIを追加
- ユーザーが「1月1日を締め切り」と意図した場合に、誤って「1月1日 00:00」（その日の開始）を設定してしまう問題を防止

## Changes

### 新規UI
- 日付選択入力（`type="date"`）を追加
  - 選択すると自動的にその日の23:59をdatetime-localにセット
- 締め切りクリアボタン（✕）を追加
- ヘルプテキスト「上の日付選択で簡単に「その日の23:59」を設定できます」を追加

### 既存機能の維持
- `datetime-local` 入力は残しており、詳細な時刻指定も可能

## UI

```
回答締切（任意）
[日付選択入力] の23:59に設定
[datetime-local入力] [✕]
上の日付選択で簡単に「その日の23:59」を設定できます
```

## Test plan
- [ ] 日付選択で日付を選ぶと、datetime-localに「YYYY-MM-DDT23:59」が設定される
- [ ] datetime-localで直接時刻を変更できる
- [ ] ✕ボタンで締め切りをクリアできる
- [ ] 出欠確認作成後、締め切りが正しく保存される

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)