### PR TITLE
docs: v1.7.0デプロイ障害のインシデントレポート追加

### DIFF
--- a/docs/incidents/2026-01-17-v1.7.0-deployment-failure.md
+++ b/docs/incidents/2026-01-17-v1.7.0-deployment-failure.md
@@ -67,7 +67,8 @@ Blocked request. This host ("vrcshift.com") is not allowed.
 
 1. **緊急バックアップ取得**
    ```bash
-   docker exec vrc-shift-db pg_dump -U vrcshift vrcshift > /opt/backup_emergency.sql
+   # 永続ストレージにバックアップを保存
+   docker exec vrc-shift-db pg_dump -U vrcshift vrcshift > <永続ストレージ>/backup_emergency.sql
    ```
 
 2. **v1.6.0へロールバック**
@@ -129,7 +130,7 @@ Blocked request. This host ("vrcshift.com") is not allowed.
    - 焦っていても`docker-compose.prod.yml`を使用する
 
 3. **バックアップは複数世代・複数場所に保管**
-   - `/tmp`は再起動で消えるため、`/opt`など永続的な場所に保管
+   - 一時ストレージは再起動で消えるため、永続的なストレージに保管
 
 4. **書き込み停止してからマイグレーション作業を行う**
    - backendを停止してからDB操作を行うことで、データ不整合を防止
@@ -138,7 +139,9 @@ Blocked request. This host ("vrcshift.com") is not allowed.
 
 - #166: 【緊急】v1.7.0デプロイ後の500エラー：マイグレーション不整合の修正が必要
 
-## バックアップファイル
+## バックアップ
 
-- `/opt/backup_before_migration_20260117_080134.sql` - マイグレーション作業直前
-- `/tmp/backup_emergency_20260117_073442.sql` - 緊急バックアップ（要移動）
+- マイグレーション作業直前のバックアップを永続ストレージに保管済み
+- 緊急バックアップを一時ストレージから永続ストレージに移動済み
+
+※ 具体的なパスは運用ドキュメント参照


### PR DESCRIPTION
## Summary

2026-01-17に発生したv1.7.0デプロイ障害のインシデントレポートを追加します。

## 内容

- `docs/incidents/2026-01-17-v1.7.0-deployment-failure.md` を新規作成
- タイムライン、根本原因、解決策、再発防止策を記載

## 関連

- Issue #166: 【緊急】v1.7.0デプロイ後の500エラー：マイグレーション不整合の修正が必要

## 学んだこと

1. マイグレーション記録の整合性は定期的に確認すべき
2. ロールバックも本番環境設定（docker-compose.prod.yml）で行う
3. バックアップは複数世代・複数場所に保管
4. 書き込み停止してからマイグレーション作業を行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)