### PR TITLE
fix: instance_idのバリデーションを既存データと互換性を持たせる

### DIFF
--- a/backend/internal/domain/shift/instance.go
+++ b/backend/internal/domain/shift/instance.go
@@ -25,25 +25,35 @@ func (id InstanceID) String() string {
 	return string(id)
 }
 
+// instanceIDPattern は26文字の英数字（大文字）を許可
+// 既存データがULID形式ではなく、26文字の英数字形式で保存されているため、
+// 後方互換性のために両方の形式を許可する
+var instanceIDPattern = regexp.MustCompile(`^[0-9A-Z]{26}$`)
+
+// validateInstanceIDFormat はinstance_idのフォーマットを検証する
+// ULIDまたは26文字の大文字英数字を許可（後方互換性のため）
+func validateInstanceIDFormat(s string) error {
+	// まずULIDとして検証を試みる
+	if err := common.ValidateULID(s); err == nil {
+		return nil
+	}
+	// ULIDでない場合、26文字の英数字（大文字）であれば許可
+	if !instanceIDPattern.MatchString(s) {
+		return common.NewValidationError("invalid instance_id format: must be 26 uppercase alphanumeric characters", nil)
+	}
+	return nil
+}
+
 func (id InstanceID) Validate() error {
 	if id == "" {
 		return common.NewValidationError("instance_id is required", nil)
 	}
-	return common.ValidateULID(string(id))
+	return validateInstanceIDFormat(string(id))
 }
 
-// instanceIDPattern は26文字の英数字（大文字）を許可
-var instanceIDPattern = regexp.MustCompile(`^[0-9A-Z]{26}$`)
-
 func ParseInstanceID(s string) (InstanceID, error) {
-	// まずULIDとして検証を試みる
-	if err := common.ValidateULID(s); err == nil {
-		return InstanceID(s), nil
-	}
-	// ULIDでない場合、26文字の英数字（大文字）であれば許可
-	// （既存データとの互換性のため）
-	if !instanceIDPattern.MatchString(s) {
-		return "", common.NewValidationError("invalid instance_id format: must be 26 uppercase alphanumeric characters", nil)
+	if err := validateInstanceIDFormat(s); err != nil {
+		return "", err
 	}
 	return InstanceID(s), nil
 }


### PR DESCRIPTION
## Summary

- PR #171 マージ後に発生した「Invalid instance_id format」エラーを修正
- 既存のinstance_idがULID形式ではなく、26文字の英数字形式で保存されていた問題に対応
- ParseInstanceID関数を修正し、既存データとの互換性を確保

## 修正内容

### バックエンド
- **ドメイン層**: `ParseInstanceID`関数を修正
  - 標準的なULID形式を優先的に検証
  - ULIDでない場合、26文字の大文字英数字も許可（既存データとの互換性）

## Test plan

- [x] バックエンドユニットテスト (`go test ./...`)
- [ ] 手動テスト: シフト枠作成画面でインスタンスを選択して作成

## Related Issues

PR #171 のフォローアップ修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)