### PR TITLE
fix: ロール/グループ割り当てのN+1問題を解消 (Closes #115)

### DIFF
--- a/backend/internal/infra/db/attendance_repository.go
+++ b/backend/internal/infra/db/attendance_repository.go
@@ -692,6 +692,7 @@ func (r *AttendanceRepository) scanCollection(
 }
 
 // SaveTargetDates saves target dates for a collection
+// Uses multi-row INSERT for atomicity and performance
 func (r *AttendanceRepository) SaveTargetDates(ctx context.Context, collectionID common.CollectionID, targetDates []*attendance.TargetDate) error {
 	executor := GetTx(ctx, r.pool)
 
@@ -707,14 +708,17 @@ func (r *AttendanceRepository) SaveTargetDates(ctx context.Context, collectionID
 		return nil
 	}
 
-	insertQuery := `
-		INSERT INTO attendance_target_dates (
-			target_date_id, collection_id, target_date, start_time, end_time, display_order, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`
+	// マルチロー INSERT で一括挿入（部分的な失敗を防ぐ）
+	// VALUES ($1, ..., $7), ($8, ..., $14), ... の形式で構築
+	const numCols = 7
+	valueStrings := make([]string, 0, len(targetDates))
+	args := make([]interface{}, 0, len(targetDates)*numCols)
 
-	for _, td := range targetDates {
-		_, err := executor.Exec(ctx, insertQuery,
+	for i, td := range targetDates {
+		base := i * numCols
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+			base+1, base+2, base+3, base+4, base+5, base+6, base+7))
+		args = append(args,
 			td.TargetDateID().String(),
 			td.CollectionID().String(),
 			td.TargetDateValue(),
@@ -723,9 +727,17 @@ func (r *AttendanceRepository) SaveTargetDates(ctx context.Context, collectionID
 			td.DisplayOrder(),
 			td.CreatedAt(),
 		)
-		if err != nil {
-			return fmt.Errorf("failed to save target date: %w", err)
-		}
+	}
+
+	insertQuery := fmt.Sprintf(`
+		INSERT INTO attendance_target_dates (
+			target_date_id, collection_id, target_date, start_time, end_time, display_order, created_at
+		) VALUES %s
+	`, strings.Join(valueStrings, ", "))
+
+	_, err = executor.Exec(ctx, insertQuery, args...)
+	if err != nil {
+		return fmt.Errorf("failed to save target dates: %w", err)
 	}
 
 	return nil
@@ -797,6 +809,7 @@ func (r *AttendanceRepository) FindTargetDatesByCollectionID(ctx context.Context
 }
 
 // SaveGroupAssignments saves group assignments for a collection (deletes existing ones first)
+// Uses multi-row INSERT for atomicity and performance
 func (r *AttendanceRepository) SaveGroupAssignments(ctx context.Context, collectionID common.CollectionID, assignments []*attendance.CollectionGroupAssignment) error {
 	executor := GetTx(ctx, r.pool)
 
@@ -812,21 +825,25 @@ func (r *AttendanceRepository) SaveGroupAssignments(ctx context.Context, collect
 		return nil
 	}
 
-	insertQuery := `
+	// マルチロー INSERT で一括挿入（部分的な失敗を防ぐ）
+	// VALUES ($1, $2, $3), ($4, $5, $6), ... の形式で構築
+	valueStrings := make([]string, 0, len(assignments))
+	args := make([]interface{}, 0, len(assignments)*3)
+
+	for i, a := range assignments {
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d)", i*3+1, i*3+2, i*3+3))
+		args = append(args, a.CollectionID().String(), a.GroupID().String(), a.CreatedAt())
+	}
+
+	insertQuery := fmt.Sprintf(`
 		INSERT INTO attendance_collection_group_assignments (
 			collection_id, group_id, created_at
-		) VALUES ($1, $2, $3)
-	`
+		) VALUES %s
+	`, strings.Join(valueStrings, ", "))
 
-	for _, a := range assignments {
-		_, err := executor.Exec(ctx, insertQuery,
-			a.CollectionID().String(),
-			a.GroupID().String(),
-			a.CreatedAt(),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to save group assignment: %w", err)
-		}
+	_, err = executor.Exec(ctx, insertQuery, args...)
+	if err != nil {
+		return fmt.Errorf("failed to save group assignments: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- SaveGroupAssignmentsをバッチINSERT化（N+1問題解消）
- SaveTargetDatesをバッチINSERT化（N+1問題解消）
- SaveRoleAssignmentsの既存実装パターンを踏襲

## 変更内容
| 関数名 | 変更前 | 変更後 |
|--------|--------|--------|
| SaveGroupAssignments | ループINSERT | マルチロー INSERT |
| SaveTargetDates | ループINSERT | マルチロー INSERT |

## Test plan
- [ ] 出欠確認の新規作成でグループ割り当てが正常に保存される
- [ ] 出欠確認の対象日設定が正常に保存される
- [ ] 既存の単体テストがパスする

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)