### PR TITLE
chore: docs/task/ を.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ coverage/
 # Local Only (not for git)
 # ===========================
 LOCAL_DEPLOY_GUIDE.md
+docs/task/
 
 # Analysis files (contains customer data)
 *.xlsx


### PR DESCRIPTION
## 概要
ローカルタスク管理用のディレクトリ `docs/task/` をgit管理対象外に設定。

## 変更内容
- `.gitignore` に `docs/task/` を追加

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>