### PR TITLE
feat: インタラクティブチュートリアル機能追加 (Issue #258)

### DIFF
--- a/web-frontend/package-lock.json
+++ b/web-frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "autoprefixer": "^10.4.22",
+        "driver.js": "^1.4.0",
+        "msw": "^2.12.10",
         "postcss": "^8.5.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -950,6 +952,89 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -999,6 +1084,45 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.57.0",
@@ -1437,7 +1561,7 @@
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1462,6 +1586,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.1",
@@ -2101,7 +2231,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2292,26 +2421,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/chalk/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/chalk/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2334,6 +2443,79 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2532,11 +2714,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.263",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.263.tgz",
       "integrity": "sha512-DrqJ11Knd+lo+dv+lltvfMDLU27g14LMdH2b0O3Pio4uk0x+z7OR+JrmyacTPN2M8w3BrZ7/RTwG3R9B7irPlg==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -3030,6 +3224,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3062,6 +3265,21 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
@@ -3141,6 +3359,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3163,6 +3390,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3595,6 +3828,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.12.10",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.10.tgz",
+      "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3725,6 +4011,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -3737,6 +4029,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3931,6 +4229,15 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3940,6 +4247,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -3986,6 +4299,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -4017,6 +4342,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -4024,12 +4358,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
@@ -4099,7 +4477,6 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.19"
@@ -4112,7 +4489,6 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/totalist": {
@@ -4129,7 +4505,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -4151,11 +4526,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4193,8 +4583,17 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",
@@ -4587,6 +4986,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -4625,6 +5053,54 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zod": {
       "version": "4.1.13",

--- a/web-frontend/package.json
+++ b/web-frontend/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "autoprefixer": "^10.4.22",
+    "driver.js": "^1.4.0",
+    "msw": "^2.12.10",
     "postcss": "^8.5.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -44,5 +46,10 @@
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
     "vitest": "^4.0.18"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/web-frontend/public/mockServiceWorker.js
+++ b/web-frontend/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.12.10'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -28,6 +28,7 @@ import CalendarList from './pages/CalendarList';
 import CalendarDetail from './pages/CalendarDetail';
 // BillingManagement は管理フロントエンド（admin-frontend）に移動しました
 import Layout from './components/Layout';
+import { OnboardingProvider } from './features/onboarding/OnboardingContext';
 import AttendanceResponse from './pages/public/AttendanceResponse';
 import ScheduleResponse from './pages/public/ScheduleResponse';
 import PublicCalendar from './pages/public/PublicCalendar';
@@ -108,7 +109,7 @@ function App() {
       <Route path="/subscribe/cancel" element={<SubscribeCancel />} />
 
       {/* ログイン必須の画面（Layoutでラップ） */}
-      <Route element={isLoggedIn ? <Layout /> : <Navigate to="/admin/login" replace />}>
+      <Route element={isLoggedIn ? <OnboardingProvider><Layout /></OnboardingProvider> : <Navigate to="/admin/login" replace />}>
         <Route path="/admin" element={<Navigate to="/events" replace />} />
         <Route path="/events" element={<EventList />} />
         <Route path="/events/:eventId/business-days" element={<BusinessDayList />} />

--- a/web-frontend/src/components/Layout.tsx
+++ b/web-frontend/src/components/Layout.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { Outlet, Link, useNavigate, useLocation } from 'react-router-dom';
 import { AnnouncementBell } from './AnnouncementBell';
 import { TutorialButton } from './TutorialButton';
+import { StartTutorialButton } from '../features/onboarding/components/StartTutorialButton';
+import { OnboardingTour } from '../features/onboarding/OnboardingTour';
 import { useDocumentTitle, getTitleFromPath } from '../hooks/useDocumentTitle';
 
 export default function Layout() {
@@ -102,19 +104,20 @@ export default function Layout() {
 
         {/* ナビゲーション */}
         <nav className="flex-1 p-3 space-y-1 overflow-y-auto">
-          <Link to="/events" className={linkClass('/events')} onClick={handleNavClick}>
+          <Link to="/events" id="nav-events" className={linkClass('/events')} onClick={handleNavClick}>
             イベント
           </Link>
-          <Link to="/members" className={linkClass('/members')} onClick={handleNavClick}>
+          <Link to="/members" id="nav-members" className={linkClass('/members')} onClick={handleNavClick}>
             メンバー
           </Link>
-          <Link to="/roles" className={linkClass('/roles')} onClick={handleNavClick}>
+          <Link to="/roles" id="nav-roles" className={linkClass('/roles')} onClick={handleNavClick}>
             ロール
           </Link>
 
           {/* グループサブメニュー */}
           <div>
             <button
+              id="nav-groups"
               onClick={() => setShowGroupSubmenu(!showGroupSubmenu)}
               className={`w-full flex items-center justify-between px-4 py-2.5 text-sm font-medium rounded-lg transition-colors ${
                 isGroupActive
@@ -160,13 +163,13 @@ export default function Layout() {
             )}
           </div>
 
-          <Link to="/attendance" className={linkClass('/attendance')} onClick={handleNavClick}>
+          <Link to="/attendance" id="nav-attendance" className={linkClass('/attendance')} onClick={handleNavClick}>
             出欠確認
           </Link>
-          <Link to="/schedules" className={linkClass('/schedules')} onClick={handleNavClick}>
+          <Link to="/schedules" id="nav-schedules" className={linkClass('/schedules')} onClick={handleNavClick}>
             日程調整
           </Link>
-          <Link to="/calendars" className={linkClass('/calendars')} onClick={handleNavClick}>
+          <Link to="/calendars" id="nav-calendars" className={linkClass('/calendars')} onClick={handleNavClick}>
             カレンダー
           </Link>
 
@@ -176,7 +179,7 @@ export default function Layout() {
             </Link>
           )}
 
-          <Link to="/settings" className={linkClass('/settings')} onClick={handleNavClick}>
+          <Link to="/settings" id="nav-settings" className={linkClass('/settings')} onClick={handleNavClick}>
             設定
           </Link>
         </nav>
@@ -206,7 +209,10 @@ export default function Layout() {
               </svg>
             </button>
             <h1 className="text-lg font-bold text-white">VRC Shift</h1>
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1" id="header-actions">
+              <div className="text-white">
+                <StartTutorialButton />
+              </div>
               <div className="text-white">
                 <TutorialButton />
               </div>
@@ -220,7 +226,8 @@ export default function Layout() {
         {/* デスクトップ用ヘッダー */}
         <header className="hidden md:flex sticky top-0 z-30 bg-white shadow-sm border-b border-gray-200">
           <div className="flex items-center justify-end w-full px-6 py-3">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2" id="header-actions-desktop">
+              <StartTutorialButton />
               <TutorialButton />
               <AnnouncementBell />
             </div>
@@ -231,6 +238,8 @@ export default function Layout() {
           <Outlet />
         </main>
       </div>
+
+      <OnboardingTour />
     </div>
   );
 }

--- a/web-frontend/src/features/onboarding/OnboardingContext.tsx
+++ b/web-frontend/src/features/onboarding/OnboardingContext.tsx
@@ -1,0 +1,131 @@
+import { createContext, useContext, useReducer, useCallback, useEffect, type ReactNode } from 'react';
+import { DUMMY_IDS, PHASE_ORDER, type OnboardingState, type OnboardingAction, type OnboardingPhase } from './steps/types';
+
+const STORAGE_KEY = 'vrcshift_onboarding';
+
+const initialState: OnboardingState = {
+  isActive: false,
+  currentPhase: 'idle',
+  dummyIds: DUMMY_IDS,
+  mswReady: false,
+};
+
+function reducer(state: OnboardingState, action: OnboardingAction): OnboardingState {
+  switch (action.type) {
+    case 'START':
+      return { ...state, isActive: true, currentPhase: 'sidebar' };
+    case 'STOP':
+      return { ...initialState };
+    case 'SET_PHASE':
+      return { ...state, currentPhase: action.phase };
+    case 'NEXT_PHASE': {
+      const currentIndex = PHASE_ORDER.indexOf(state.currentPhase);
+      if (currentIndex < 0 || currentIndex >= PHASE_ORDER.length - 1) {
+        return { ...state, currentPhase: 'complete' };
+      }
+      return { ...state, currentPhase: PHASE_ORDER[currentIndex + 1] };
+    }
+    case 'SET_MSW_READY':
+      return { ...state, mswReady: action.ready };
+    case 'RESTORE':
+      return action.state;
+    default:
+      return state;
+  }
+}
+
+interface OnboardingContextValue {
+  state: OnboardingState;
+  startTour: () => Promise<void>;
+  stopTour: () => Promise<void>;
+  setPhase: (phase: OnboardingPhase) => void;
+  nextPhase: () => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState, () => {
+    // sessionStorage から復元を試みる
+    try {
+      const saved = sessionStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as OnboardingState;
+        if (parsed.isActive) {
+          return { ...parsed, mswReady: false };
+        }
+      }
+    } catch {
+      // パースエラーは無視
+    }
+    return initialState;
+  });
+
+  // sessionStorage に永続化
+  useEffect(() => {
+    if (state.isActive) {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } else {
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }, [state]);
+
+  const startTour = useCallback(async () => {
+    try {
+      const { startMSW } = await import('./mocks/browser');
+      await startMSW();
+      dispatch({ type: 'SET_MSW_READY', ready: true });
+      dispatch({ type: 'START' });
+    } catch {
+      // MSW起動失敗（ブラウザ非対応等）→ ツアーは開始しない
+    }
+  }, []);
+
+  const stopTour = useCallback(async () => {
+    try {
+      const { stopMSW } = await import('./mocks/browser');
+      stopMSW();
+    } catch {
+      // ignore
+    }
+    dispatch({ type: 'STOP' });
+  }, []);
+
+  const setPhase = useCallback((phase: OnboardingPhase) => {
+    dispatch({ type: 'SET_PHASE', phase });
+  }, []);
+
+  const nextPhase = useCallback(() => {
+    dispatch({ type: 'NEXT_PHASE' });
+  }, []);
+
+  // MSW復元（セッションリストア時）
+  useEffect(() => {
+    if (!state.isActive || state.mswReady) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { startMSW } = await import('./mocks/browser');
+        await startMSW();
+        if (!cancelled) {
+          dispatch({ type: 'SET_MSW_READY', ready: true });
+        }
+      } catch {
+        // MSW復元失敗時は無視（次回リロードで再試行）
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [state.isActive, state.mswReady]);
+
+  return (
+    <OnboardingContext.Provider value={{ state, startTour, stopTour, setPhase, nextPhase }}>
+      {children}
+    </OnboardingContext.Provider>
+  );
+}
+
+export function useOnboardingContext() {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) throw new Error('useOnboardingContext must be used within OnboardingProvider');
+  return ctx;
+}

--- a/web-frontend/src/features/onboarding/OnboardingTour.tsx
+++ b/web-frontend/src/features/onboarding/OnboardingTour.tsx
@@ -1,0 +1,696 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { driver, type DriveStep, type Config } from 'driver.js';
+import 'driver.js/dist/driver.css';
+import './onboarding.css';
+import { useOnboarding, waitForElement, delay, setReactInputValue } from './hooks/useOnboarding';
+import { DUMMY_IDS } from './steps/types';
+
+type DriverInstance = ReturnType<typeof driver>;
+
+export function OnboardingTour() {
+  const { state, stopTour, setPhase, navigate } = useOnboarding();
+  const driverRef = useRef<DriverInstance | null>(null);
+  const location = useLocation();
+
+  // ドライバー破棄
+  const destroyDriver = useCallback(() => {
+    if (driverRef.current) {
+      driverRef.current.destroy();
+      driverRef.current = null;
+    }
+  }, []);
+
+  // ESCキーで中断確認
+  useEffect(() => {
+    if (!state.isActive) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        destroyDriver();
+        // ESC 中断 → 確認はStartTutorialButtonのUIに委ねる
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [state.isActive, destroyDriver]);
+
+  // フェーズ変更時にドライバーを再作成
+  useEffect(() => {
+    if (!state.isActive || !state.mswReady || state.currentPhase === 'idle') return;
+
+    const runPhase = async () => {
+      destroyDriver();
+      await delay(200);
+
+      switch (state.currentPhase) {
+        case 'sidebar':
+          await runSidebarPhase();
+          break;
+        case 'role':
+          await runRolePhase();
+          break;
+        case 'event':
+          await runEventPhase();
+          break;
+        case 'template':
+          await runTemplatePhase();
+          break;
+        case 'businessDay':
+          await runBusinessDayPhase();
+          break;
+        case 'shiftSlot':
+          await runShiftSlotPhase();
+          break;
+        case 'member':
+          await runMemberPhase();
+          break;
+        case 'attendance':
+          await runAttendancePhase();
+          break;
+        case 'attendanceResponse':
+          await runAttendanceResponsePhase();
+          break;
+        case 'attendanceDetail':
+          await runAttendanceDetailPhase();
+          break;
+        case 'shiftAdjustment':
+          await runShiftAdjustmentPhase();
+          break;
+        case 'calendar':
+          await runCalendarPhase();
+          break;
+        case 'summary':
+          await runSummaryPhase();
+          break;
+        case 'complete':
+          await runCompletePhase();
+          break;
+      }
+    };
+
+    runPhase();
+
+    return () => destroyDriver();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- フェーズ変更のみトリガー
+  }, [state.currentPhase, state.isActive, state.mswReady]);
+
+  // ドライバー作成ヘルパー
+  function createDriver(steps: DriveStep[], onComplete: () => void, config?: Partial<Config>) {
+    const d = driver({
+      showProgress: true,
+      animate: true,
+      allowClose: false,
+      overlayClickBehavior: () => { /* overlay クリック無効化 */ },
+      stagePadding: 8,
+      stageRadius: 8,
+      steps,
+      onDestroyStarted: () => {
+        d.destroy();
+        // 最後のステップなら完了処理（次フェーズへ遷移）
+        if (d.isLastStep()) {
+          onComplete();
+        }
+      },
+      ...config,
+    });
+    driverRef.current = d;
+    d.drive();
+    return d;
+  }
+
+  // 要素クリックをシミュレート
+  function clickElement(selector: string) {
+    const el = document.querySelector(selector);
+    if (el instanceof HTMLElement) {
+      el.click();
+    }
+  }
+
+  // === Phase implementations ===
+
+  async function runSidebarPhase() {
+    if (!location.pathname.startsWith('/events')) {
+      await navigate('/events');
+    }
+
+    createDriver([
+      {
+        popover: {
+          title: 'VRC Shift Scheduler へようこそ！',
+          description: 'このツアーでは、シフト管理の全機能を体験します。ダミーデータを使うので実データには影響しません。',
+        },
+      },
+      {
+        element: '#nav-events',
+        popover: {
+          title: 'イベント',
+          description: 'イベント（バーやクラブなど）を管理します。イベントごとに営業日やシフトを設定できます。',
+        },
+      },
+      {
+        element: '#nav-members',
+        popover: {
+          title: 'メンバー',
+          description: 'シフトに参加するメンバーを管理します。ロールやグループで分類できます。',
+        },
+      },
+      {
+        element: '#nav-roles',
+        popover: {
+          title: 'ロール',
+          description: 'バーテンダーやMCなど、メンバーの役割を定義します。次のステップで実際に作成してみましょう。',
+        },
+      },
+      {
+        element: '#nav-attendance',
+        popover: {
+          title: '出欠確認',
+          description: 'メンバーに出欠を確認し、回答を集計します。URLを送るだけで簡単に回答してもらえます。',
+        },
+      },
+      {
+        element: '#nav-calendars',
+        popover: {
+          title: 'カレンダー',
+          description: 'シフト予定を外部共有できるカレンダーです。では、まずロールを作成しましょう！',
+        },
+      },
+    ], () => {
+      setPhase('role');
+    });
+  }
+
+  async function runRolePhase() {
+    await navigate('/roles');
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-role',
+        popover: {
+          title: 'ロールを作成しましょう',
+          description: '「バーテンダー」ロールを作成します。ボタンをクリックしてください。',
+        },
+        onHighlightStarted: () => {
+          // 自動で次のステップでクリックを実行
+        },
+      },
+      {
+        popover: {
+          title: 'ロール作成',
+          description: 'ロール作成モーダルを開きます...',
+          onNextClick: async () => {
+            clickElement('#btn-create-role');
+            await waitForElement('.fixed.inset-0'); // モーダル待ち
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#name',
+        popover: {
+          title: 'ロール名を入力',
+          description: '「バーテンダー」と入力します。',
+          onNextClick: async () => {
+            const input = document.querySelector('#name') as HTMLInputElement;
+            if (input) setReactInputValue(input, 'バーテンダー');
+            await delay(200);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#btn-submit-role',
+        popover: {
+          title: '作成！',
+          description: '作成ボタンをクリックして、ロールを登録します。',
+          onNextClick: async () => {
+            clickElement('#btn-submit-role');
+            await delay(800);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'ロール作成完了！',
+          description: 'バーテンダーロールが作成されました。次はイベントを作成しましょう！',
+        },
+      },
+    ], () => {
+      setPhase('event');
+    });
+  }
+
+  async function runEventPhase() {
+    await navigate('/events');
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-event',
+        popover: {
+          title: 'イベントを作成',
+          description: '「チュートリアル Bar」イベントを作成します。',
+          onNextClick: async () => {
+            clickElement('#btn-create-event');
+            await waitForElement('.fixed.inset-0');
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#eventName',
+        popover: {
+          title: 'イベント名',
+          description: '「チュートリアル Bar」と入力します。',
+          onNextClick: async () => {
+            const input = document.querySelector('#eventName') as HTMLInputElement;
+            if (input) setReactInputValue(input, 'チュートリアル Bar');
+            await delay(200);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#btn-submit-event',
+        popover: {
+          title: '作成！',
+          description: 'イベントを作成します。',
+          onNextClick: async () => {
+            clickElement('#btn-submit-event');
+            await delay(800);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'イベント作成完了！',
+          description: 'チュートリアル Bar が作成されました。次はシフトテンプレートを作成しましょう。',
+        },
+      },
+    ], () => {
+      setPhase('template');
+    });
+  }
+
+  async function runTemplatePhase() {
+    await navigate(`/events/${DUMMY_IDS.eventId}/business-days`);
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#link-template-management',
+        popover: {
+          title: 'テンプレート管理',
+          description: 'テンプレートを使うと、シフト枠の構成を再利用できます。テンプレート管理ページへ移動しましょう。',
+          onNextClick: async () => {
+            await navigate(`/events/${DUMMY_IDS.eventId}/templates`);
+            await delay(500);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#btn-create-template',
+        popover: {
+          title: '新規テンプレート作成',
+          description: 'テンプレートを作成します。',
+          onNextClick: async () => {
+            await navigate(`/events/${DUMMY_IDS.eventId}/templates/new`);
+            await delay(500);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#templateName',
+        popover: {
+          title: 'テンプレート名',
+          description: '「メインインスタンス構成」と入力します。',
+          onNextClick: async () => {
+            const input = document.querySelector('#templateName') as HTMLInputElement;
+            if (input) setReactInputValue(input, 'メインインスタンス構成');
+            await delay(200);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'テンプレートの仕組み',
+          description: 'テンプレートには「インスタンス」と「役職」を定義します。インスタンスはVRChatのワールドインスタンスに対応し、役職はバーテンダーやMCなどのシフト枠です。\n\nここでは、MSWがテンプレート作成をシミュレートします。',
+          onNextClick: async () => {
+            // MSWがテンプレート作成をインターセプト
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'テンプレート作成完了！',
+          description: '「メインインスタンス構成」テンプレートが作成されました。メインフロアにバーテンダー2名、MC1名の構成です。\n\n次は営業日を作成し、このテンプレートを適用しましょう。',
+        },
+      },
+    ], () => {
+      setPhase('businessDay');
+    });
+  }
+
+  async function runBusinessDayPhase() {
+    await navigate(`/events/${DUMMY_IDS.eventId}/business-days`);
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-business-day',
+        popover: {
+          title: '営業日を追加',
+          description: '営業日を作成します。テンプレートを選択すると、シフト枠が自動的に作成されます。',
+          onNextClick: async () => {
+            clickElement('#btn-create-business-day');
+            await waitForElement('.fixed.inset-0');
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'テンプレートを選択',
+          description: '先ほど作成した「メインインスタンス構成」テンプレートを選択します。テンプレートを選ぶと、バーテンダー2名・MC1名のシフト枠が自動作成されます。',
+          onNextClick: async () => {
+            // MSWが営業日+シフト枠をインターセプト
+            await delay(500);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: '営業日作成完了！',
+          description: '営業日が作成され、テンプレートからシフト枠が自動作成されました。シフト枠を確認しましょう。',
+        },
+      },
+    ], () => {
+      setPhase('shiftSlot');
+    });
+  }
+
+  async function runShiftSlotPhase() {
+    await navigate(`/business-days/${DUMMY_IDS.businessDayId}/shift-slots`);
+    await delay(500);
+
+    createDriver([
+      {
+        popover: {
+          title: 'シフト枠一覧',
+          description: 'テンプレートから自動作成されたシフト枠です。「メインフロア」インスタンスに、バーテンダー（2名）とMC（1名）の枠があります。',
+        },
+      },
+      {
+        popover: {
+          title: 'シフト枠の構造',
+          description: 'シフト枠はインスタンスごとにグループ化されています。各枠には役職名、必要人数、時間帯が設定されています。\n\nテンプレートを使えば、毎回同じ構成を簡単に適用できます。',
+        },
+      },
+      {
+        popover: {
+          title: '次はメンバー追加',
+          description: 'シフト枠が準備できました。次はメンバーを追加して、シフトに割り当てましょう。',
+        },
+      },
+    ], () => {
+      setPhase('member');
+    });
+  }
+
+  async function runMemberPhase() {
+    await navigate('/members');
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-member',
+        popover: {
+          title: 'メンバーを追加',
+          description: '3名のメンバーを追加します。',
+          onNextClick: async () => {
+            clickElement('#btn-create-member');
+            await waitForElement('.fixed.inset-0');
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#member-display-name',
+        popover: {
+          title: 'メンバー名を入力',
+          description: '「田中太郎」と入力します。',
+          onNextClick: async () => {
+            const input = document.querySelector('#member-display-name') as HTMLInputElement;
+            if (input) setReactInputValue(input, '田中太郎');
+            await delay(200);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        element: '#btn-submit-member',
+        popover: {
+          title: '登録！',
+          description: 'メンバーを登録します。',
+          onNextClick: async () => {
+            clickElement('#btn-submit-member');
+            await delay(800);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'メンバー追加完了！',
+          description: '3名のメンバー（田中太郎、佐藤花子、鈴木一郎）が追加されました。各メンバーにロールも割り当て済みです。\n\n次は出欠確認を作成しましょう！',
+        },
+      },
+    ], () => {
+      setPhase('attendance');
+    });
+  }
+
+  async function runAttendancePhase() {
+    await navigate('/attendance');
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-attendance',
+        popover: {
+          title: '出欠確認を作成',
+          description: 'メンバーに出欠を確認するフォームを作成します。',
+          onNextClick: async () => {
+            clickElement('#btn-create-attendance');
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: '出欠確認の仕組み',
+          description: '出欠確認を作成すると、公開URLが発行されます。このURLをメンバーに送信すると、各日の参加/不参加を回答してもらえます。\n\nイベントから日程を取り込むこともでき、締切も設定できます。',
+          onNextClick: async () => {
+            // MSWが出欠確認作成をインターセプト
+            await delay(500);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: '出欠確認作成完了！',
+          description: '出欠確認が作成され、公開URLが発行されました。\n\n次のステップでは、メンバーがどのように回答するかを説明します。',
+        },
+      },
+    ], () => {
+      setPhase('attendanceResponse');
+    });
+  }
+
+  async function runAttendanceResponsePhase() {
+    createDriver([
+      {
+        popover: {
+          title: '出欠の回答方法',
+          description: 'メンバーは公開URLを開いて、自分の名前を選択し、各日程の参加/不参加を回答します。\n\n参加可能時間帯やメモも入力できます。',
+        },
+      },
+      {
+        popover: {
+          title: '回答が集まりました',
+          description: '3名全員が「参加」と回答しました。回答状況を詳細画面で確認しましょう。',
+        },
+      },
+    ], () => {
+      setPhase('attendanceDetail');
+    });
+  }
+
+  async function runAttendanceDetailPhase() {
+    await navigate(`/attendance/${DUMMY_IDS.collectionId}`);
+    await delay(500);
+
+    createDriver([
+      {
+        popover: {
+          title: '出欠確認詳細',
+          description: '回答状況を一覧で確認できます。各メンバーの参加/不参加が表示されています。',
+        },
+      },
+      {
+        element: '#btn-close-collection',
+        popover: {
+          title: '締め切り',
+          description: '「締め切る」ボタンで出欠の受付を終了できます。締切後は回答の変更ができなくなります。',
+        },
+      },
+      {
+        element: '#btn-shift-adjustment',
+        popover: {
+          title: 'シフト調整へ',
+          description: '出欠結果をもとに、シフトの割り当てを行います。次のステップで体験しましょう！',
+        },
+      },
+    ], () => {
+      setPhase('shiftAdjustment');
+    });
+  }
+
+  async function runShiftAdjustmentPhase() {
+    await navigate(`/attendance/${DUMMY_IDS.collectionId}/shift-adjustment`);
+    await delay(500);
+
+    createDriver([
+      {
+        popover: {
+          title: 'シフト調整',
+          description: '出欠確認の結果をもとに、各シフト枠にメンバーを割り当てます。',
+        },
+      },
+      {
+        element: '#shift-date-tabs',
+        popover: {
+          title: '日付タブ',
+          description: '複数日程がある場合、タブで切り替えられます。',
+        },
+      },
+      {
+        element: '#shift-attending-members',
+        popover: {
+          title: '参加メンバー',
+          description: '「参加」と回答したメンバーの一覧です。ここからシフト枠に割り当てます。',
+        },
+      },
+      {
+        element: '#shift-slot-assignments',
+        popover: {
+          title: 'シフト枠割り当て',
+          description: 'テンプレートで定義した枠（バーテンダー2名、MC1名）にメンバーを割り当てます。\n\nドロップダウンからメンバーを選んで「追加」ボタンで割り当てます。',
+        },
+      },
+      {
+        popover: {
+          title: 'シフト調整完了！',
+          description: 'シフトの割り当てができました。最後にカレンダー機能を確認しましょう！',
+        },
+      },
+    ], () => {
+      setPhase('calendar');
+    });
+  }
+
+  async function runCalendarPhase() {
+    await navigate('/calendars');
+    await delay(500);
+
+    createDriver([
+      {
+        element: '#btn-create-calendar',
+        popover: {
+          title: 'カレンダーを作成',
+          description: 'カレンダーを作成して、シフト予定を外部共有できます。',
+          onNextClick: async () => {
+            clickElement('#btn-create-calendar');
+            await waitForElement('.fixed.inset-0');
+            await delay(300);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'カレンダーの仕組み',
+          description: 'カレンダーにはイベントを紐付けます。公開URLを共有すると、メンバーがシフト予定を確認できます。',
+          onNextClick: async () => {
+            // MSWがカレンダー作成をインターセプト
+            await delay(500);
+            driverRef.current?.moveNext();
+          },
+        },
+      },
+      {
+        popover: {
+          title: 'カレンダー作成完了！',
+          description: '公開URLを共有すると、誰でもシフト予定を閲覧できます。\n\nこれで全機能の体験が完了しました！',
+        },
+      },
+    ], () => {
+      setPhase('summary');
+    });
+  }
+
+  async function runSummaryPhase() {
+    createDriver([
+      {
+        popover: {
+          title: '全機能まとめ',
+          description: [
+            '体験した機能の振り返り:',
+            '',
+            '1. ロール: メンバーの役割を定義（バーテンダー、MC等）',
+            '2. テンプレート: シフト構成を再利用可能な形で保存',
+            '3. イベント → 営業日 → シフト枠: 階層構造でシフトを管理',
+            '4. 出欠確認 → シフト調整: 出欠を集計してシフトに反映',
+            '5. カレンダー: シフト予定を外部共有',
+          ].join('\n'),
+        },
+      },
+    ], () => {
+      setPhase('complete');
+    });
+  }
+
+  async function runCompletePhase() {
+    createDriver([
+      {
+        popover: {
+          title: 'チュートリアル完了！',
+          description: 'お疲れ様でした！全ての機能を体験できました。\n\nこの画面を閉じるとダミーデータは自動的にクリーンアップされます。\n\nもう一度体験したい場合は、ヘッダーの「体験ツアー」ボタンから再開できます。',
+        },
+      },
+    ], async () => {
+      await stopTour();
+      window.location.reload();
+    });
+  }
+
+  // チュートリアルがアクティブでないときは何も表示しない
+  if (!state.isActive) return null;
+
+  return null; // driver.jsはDOM操作で表示するため、React要素は不要
+}

--- a/web-frontend/src/features/onboarding/components/StartTutorialButton.tsx
+++ b/web-frontend/src/features/onboarding/components/StartTutorialButton.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { useOnboardingContext } from '../OnboardingContext';
+
+export function StartTutorialButton() {
+  const { state, startTour, stopTour } = useOnboardingContext();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  if (state.isActive) {
+    return (
+      <button
+        onClick={() => setShowConfirm(true)}
+        className="px-3 py-1.5 text-xs font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors"
+        title="チュートリアルを中断"
+        id="btn-stop-tutorial"
+      >
+        チュートリアル中断
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setShowConfirm(true)}
+        className="px-3 py-1.5 text-xs font-medium text-accent hover:text-accent-dark bg-accent/10 hover:bg-accent/20 rounded-lg transition-colors"
+        title="インタラクティブチュートリアルを開始"
+        id="btn-start-tutorial"
+      >
+        体験ツアー
+      </button>
+
+      {showConfirm && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-[9999]">
+          <div className="bg-white rounded-lg max-w-sm w-full p-6">
+            {state.isActive ? (
+              <>
+                <h3 className="text-lg font-bold text-gray-900 mb-3">チュートリアルを中断しますか？</h3>
+                <p className="text-sm text-gray-600 mb-4">
+                  進行状況はリセットされます。ダミーデータも削除されます。
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={() => setShowConfirm(false)}
+                    className="flex-1 btn-secondary text-sm"
+                  >
+                    続ける
+                  </button>
+                  <button
+                    onClick={async () => {
+                      await stopTour();
+                      setShowConfirm(false);
+                      window.location.reload();
+                    }}
+                    className="flex-1 btn-danger text-sm"
+                  >
+                    中断する
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-bold text-gray-900 mb-3">体験ツアーを開始</h3>
+                <p className="text-sm text-gray-600 mb-2">
+                  画面上のガイドに従って、全機能を体験できます。
+                </p>
+                <ul className="text-sm text-gray-600 mb-4 space-y-1">
+                  <li>- ダミーデータを使うので実データに影響はありません</li>
+                  <li>- 途中で中断・再開できます</li>
+                  <li>- 所要時間: 約5-10分</li>
+                </ul>
+                <div className="flex gap-3">
+                  <button
+                    onClick={() => setShowConfirm(false)}
+                    className="flex-1 btn-secondary text-sm"
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    onClick={async () => {
+                      setShowConfirm(false);
+                      await startTour();
+                    }}
+                    className="flex-1 btn-primary text-sm"
+                  >
+                    開始する
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web-frontend/src/features/onboarding/hooks/useOnboarding.ts
+++ b/web-frontend/src/features/onboarding/hooks/useOnboarding.ts
@@ -1,0 +1,96 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useOnboardingContext } from '../OnboardingContext';
+import type { OnboardingPhase } from '../steps/types';
+
+/**
+ * React controlled input への値設定
+ * React 内部の state と DOM の value を同期させるため、
+ * native setter を呼び出した後に input イベントを発行する
+ */
+export function setReactInputValue(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const proto = el instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+/**
+ * select 要素への値設定
+ */
+export function setReactSelectValue(el: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+/**
+ * DOM要素の出現を待つ（MutationObserver）
+ */
+export function waitForElement(selector: string, timeout = 3000): Promise<Element | null> {
+  return new Promise((resolve) => {
+    const existing = document.querySelector(selector);
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector(selector);
+      if (el) {
+        observer.disconnect();
+        resolve(el);
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    setTimeout(() => {
+      observer.disconnect();
+      resolve(null);
+    }, timeout);
+  });
+}
+
+/**
+ * 指定時間待機
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * メインのオンボーディングフック
+ */
+export function useOnboarding() {
+  const { state, startTour, stopTour, setPhase, nextPhase } = useOnboardingContext();
+  const navigate = useNavigate();
+
+  const navigateAndWait = useCallback(async (path: string, waitMs = 300) => {
+    navigate(path);
+    await delay(waitMs);
+  }, [navigate]);
+
+  const goToPhase = useCallback(async (phase: OnboardingPhase, path?: string) => {
+    if (path) {
+      await navigateAndWait(path);
+    }
+    setPhase(phase);
+  }, [setPhase, navigateAndWait]);
+
+  return {
+    state,
+    startTour,
+    stopTour,
+    setPhase,
+    nextPhase,
+    navigate: navigateAndWait,
+    goToPhase,
+  };
+}

--- a/web-frontend/src/features/onboarding/mocks/browser.ts
+++ b/web-frontend/src/features/onboarding/mocks/browser.ts
@@ -1,0 +1,23 @@
+import { setupWorker } from 'msw/browser';
+import { handlers, resetMockState } from './handlers';
+
+let worker: ReturnType<typeof setupWorker> | null = null;
+
+export async function startMSW() {
+  if (worker) return;
+  resetMockState();
+  worker = setupWorker(...handlers);
+  await worker.start({
+    onUnhandledRequest: 'bypass',
+    serviceWorker: {
+      url: '/mockServiceWorker.js',
+    },
+  });
+}
+
+export function stopMSW() {
+  if (worker) {
+    worker.stop();
+    worker = null;
+  }
+}

--- a/web-frontend/src/features/onboarding/mocks/data.ts
+++ b/web-frontend/src/features/onboarding/mocks/data.ts
@@ -203,6 +203,18 @@ export const DUMMY_RESPONSES = [
   },
 ];
 
+export const DUMMY_INSTANCES = [
+  {
+    instance_id: 'tut_instance_001',
+    event_id: DUMMY_IDS.eventId,
+    instance_name: 'メインフロア',
+    capacity: 40,
+    display_order: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
 export const DUMMY_CALENDAR = {
   id: DUMMY_IDS.calendarId,
   title: 'チュートリアル Bar カレンダー',

--- a/web-frontend/src/features/onboarding/mocks/data.ts
+++ b/web-frontend/src/features/onboarding/mocks/data.ts
@@ -1,0 +1,220 @@
+import { DUMMY_IDS } from '../steps/types';
+
+// 来週の土曜日を計算
+function getNextSaturday(): string {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const daysUntilSaturday = (6 - dayOfWeek + 7) % 7 || 7;
+  const nextSat = new Date(now);
+  nextSat.setDate(now.getDate() + daysUntilSaturday);
+  return nextSat.toISOString().split('T')[0];
+}
+
+const targetDate = getNextSaturday();
+
+export const DUMMY_ROLES = [
+  {
+    role_id: DUMMY_IDS.roleId1,
+    name: 'バーテンダー',
+    description: 'ドリンクの提供を担当',
+    color: '#3B82F6',
+    display_order: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    role_id: DUMMY_IDS.roleId2,
+    name: 'MC',
+    description: 'イベントの司会進行',
+    color: '#EF4444',
+    display_order: 2,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+export const DUMMY_EVENT = {
+  event_id: DUMMY_IDS.eventId,
+  event_name: 'チュートリアル Bar',
+  event_type: 'normal' as const,
+  description: 'チュートリアル用のサンプルイベントです',
+  recurrence_type: 'none' as const,
+  is_active: true,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+export const DUMMY_TEMPLATE = {
+  template_id: DUMMY_IDS.templateId,
+  event_id: DUMMY_IDS.eventId,
+  name: 'メインインスタンス構成',
+  description: 'メインフロアの基本シフト構成',
+  items: [
+    {
+      template_item_id: 'tut_ti_001',
+      instance_id: 'tut_instance_001',
+      instance_name: 'メインフロア',
+      role_name: 'バーテンダー',
+      required_count: 2,
+      start_time: '21:00:00',
+      end_time: '23:30:00',
+      priority: 1,
+    },
+    {
+      template_item_id: 'tut_ti_002',
+      instance_id: 'tut_instance_001',
+      instance_name: 'メインフロア',
+      role_name: 'MC',
+      required_count: 1,
+      start_time: '21:00:00',
+      end_time: '23:30:00',
+      priority: 2,
+    },
+  ],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+export const DUMMY_BUSINESS_DAY = {
+  business_day_id: DUMMY_IDS.businessDayId,
+  event_id: DUMMY_IDS.eventId,
+  target_date: `${targetDate}T00:00:00Z`,
+  start_time: '21:00:00',
+  end_time: '23:30:00',
+  is_active: true,
+  note: '',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+export const DUMMY_SHIFT_SLOTS = [
+  {
+    shift_slot_id: DUMMY_IDS.shiftSlotId1,
+    business_day_id: DUMMY_IDS.businessDayId,
+    instance_id: 'tut_instance_001',
+    instance_name: 'メインフロア',
+    slot_name: 'バーテンダー',
+    required_count: 2,
+    start_time: '21:00:00',
+    end_time: '23:30:00',
+    priority: 1,
+    assigned_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    shift_slot_id: DUMMY_IDS.shiftSlotId2,
+    business_day_id: DUMMY_IDS.businessDayId,
+    instance_id: 'tut_instance_001',
+    instance_name: 'メインフロア',
+    slot_name: 'MC',
+    required_count: 1,
+    start_time: '21:00:00',
+    end_time: '23:30:00',
+    priority: 2,
+    assigned_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+export const DUMMY_MEMBERS = [
+  {
+    member_id: DUMMY_IDS.memberId1,
+    display_name: '田中太郎',
+    is_active: true,
+    role_ids: [DUMMY_IDS.roleId1],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    member_id: DUMMY_IDS.memberId2,
+    display_name: '佐藤花子',
+    is_active: true,
+    role_ids: [DUMMY_IDS.roleId1, DUMMY_IDS.roleId2],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  {
+    member_id: DUMMY_IDS.memberId3,
+    display_name: '鈴木一郎',
+    is_active: true,
+    role_ids: [DUMMY_IDS.roleId2],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+export const DUMMY_COLLECTION = {
+  collection_id: DUMMY_IDS.collectionId,
+  title: 'チュートリアル Bar 出欠確認',
+  description: 'チュートリアル用の出欠確認です',
+  status: 'open' as const,
+  target_type: 'event',
+  target_id: DUMMY_IDS.eventId,
+  public_token: 'tut_token_001',
+  deadline: null,
+  target_date_count: 1,
+  response_count: 3,
+  group_ids: [],
+  role_ids: [],
+  target_dates: [
+    {
+      target_date_id: DUMMY_IDS.targetDateId1,
+      target_date: `${targetDate}T00:00:00Z`,
+      start_time: '21:00:00',
+      end_time: '23:30:00',
+    },
+  ],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+export const DUMMY_RESPONSES = [
+  {
+    response_id: 'tut_resp_001',
+    collection_id: DUMMY_IDS.collectionId,
+    member_id: DUMMY_IDS.memberId1,
+    member_name: '田中太郎',
+    answers: [
+      { target_date_id: DUMMY_IDS.targetDateId1, status: 'attending', note: '' },
+    ],
+    submitted_at: new Date().toISOString(),
+  },
+  {
+    response_id: 'tut_resp_002',
+    collection_id: DUMMY_IDS.collectionId,
+    member_id: DUMMY_IDS.memberId2,
+    member_name: '佐藤花子',
+    answers: [
+      { target_date_id: DUMMY_IDS.targetDateId1, status: 'attending', note: '' },
+    ],
+    submitted_at: new Date().toISOString(),
+  },
+  {
+    response_id: 'tut_resp_003',
+    collection_id: DUMMY_IDS.collectionId,
+    member_id: DUMMY_IDS.memberId3,
+    member_name: '鈴木一郎',
+    answers: [
+      { target_date_id: DUMMY_IDS.targetDateId1, status: 'attending', note: '' },
+    ],
+    submitted_at: new Date().toISOString(),
+  },
+];
+
+export const DUMMY_CALENDAR = {
+  id: DUMMY_IDS.calendarId,
+  title: 'チュートリアル Bar カレンダー',
+  description: 'チュートリアル用の共有カレンダー',
+  public_token: 'tut_cal_token_001',
+  event_ids: [DUMMY_IDS.eventId],
+  is_active: true,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+// チュートリアルのダミーIDかどうかを判定
+export function isTutorialId(id: string): boolean {
+  return id.startsWith('tut_');
+}

--- a/web-frontend/src/features/onboarding/mocks/handlers.ts
+++ b/web-frontend/src/features/onboarding/mocks/handlers.ts
@@ -1,0 +1,179 @@
+import { http, HttpResponse, passthrough, bypass } from 'msw';
+import { DUMMY_IDS } from '../steps/types';
+import {
+  DUMMY_ROLES,
+  DUMMY_EVENT,
+  DUMMY_TEMPLATE,
+  DUMMY_BUSINESS_DAY,
+  DUMMY_SHIFT_SLOTS,
+  DUMMY_MEMBERS,
+  DUMMY_COLLECTION,
+  DUMMY_RESPONSES,
+  DUMMY_CALENDAR,
+  isTutorialId,
+} from './data';
+
+// 内部ステート: 出欠コレクションのステータス管理
+let collectionStatus: 'open' | 'closed' = 'open';
+
+// チュートリアル開始時にステートリセット
+export function resetMockState() {
+  collectionStatus = 'open';
+}
+
+// 実APIからのGETレスポンスにダミーデータをマージするヘルパー
+async function mergeWithRealData<T extends Record<string, unknown>>(
+  request: Request,
+  url: string,
+  dataKey: string,
+  dummyItems: T[],
+) {
+  try {
+    // bypass() で MSW をスキップし、実サーバーへ直接リクエスト（無限再帰防止）
+    const realResponse = await fetch(bypass(new Request(url, {
+      headers: {
+        'Authorization': request.headers.get('Authorization') || '',
+        'Content-Type': 'application/json',
+      },
+    })));
+    if (realResponse.ok) {
+      const realData = await realResponse.json();
+      const realItems = realData[dataKey] || realData.data?.[dataKey] || [];
+      return HttpResponse.json({
+        ...realData,
+        [dataKey]: [...dummyItems, ...realItems],
+        data: realData.data ? {
+          ...realData.data,
+          [dataKey]: [...dummyItems, ...(realData.data[dataKey] || [])],
+        } : undefined,
+      });
+    }
+  } catch {
+    // 実API失敗時はダミーデータのみ返す
+  }
+  return HttpResponse.json({ [dataKey]: dummyItems });
+}
+
+export const handlers = [
+  // === ロール ===
+  http.post('/api/v1/roles', () => {
+    return HttpResponse.json({ data: DUMMY_ROLES[0] }, { status: 201 });
+  }),
+
+  http.get('/api/v1/roles', ({ request }) => {
+    return mergeWithRealData(request, request.url, 'roles', DUMMY_ROLES);
+  }),
+
+  // === イベント ===
+  http.post('/api/v1/events', () => {
+    return HttpResponse.json({ data: DUMMY_EVENT }, { status: 201 });
+  }),
+
+  http.get('/api/v1/events', ({ request }) => {
+    return mergeWithRealData(request, request.url, 'events', [DUMMY_EVENT]);
+  }),
+
+  // === テンプレート ===
+  http.get(`/api/v1/events/${DUMMY_IDS.eventId}/templates`, () => {
+    return HttpResponse.json({ data: { templates: [DUMMY_TEMPLATE] } });
+  }),
+
+  http.post(`/api/v1/events/${DUMMY_IDS.eventId}/templates`, () => {
+    return HttpResponse.json({ data: DUMMY_TEMPLATE }, { status: 201 });
+  }),
+
+  http.get(`/api/v1/events/${DUMMY_IDS.eventId}/templates/${DUMMY_IDS.templateId}`, () => {
+    return HttpResponse.json({ data: DUMMY_TEMPLATE });
+  }),
+
+  // === 営業日 ===
+  http.get(`/api/v1/events/${DUMMY_IDS.eventId}/business-days`, ({ request }) => {
+    return mergeWithRealData(request, request.url, 'business_days', [DUMMY_BUSINESS_DAY]);
+  }),
+
+  http.post(`/api/v1/events/${DUMMY_IDS.eventId}/business-days`, () => {
+    return HttpResponse.json({ data: DUMMY_BUSINESS_DAY }, { status: 201 });
+  }),
+
+  // === シフト枠 ===
+  http.get(`/api/v1/business-days/${DUMMY_IDS.businessDayId}/shift-slots`, () => {
+    return HttpResponse.json({ data: { shift_slots: DUMMY_SHIFT_SLOTS } });
+  }),
+
+  http.post(`/api/v1/business-days/${DUMMY_IDS.businessDayId}/shift-slots`, () => {
+    return HttpResponse.json({ data: DUMMY_SHIFT_SLOTS[0] }, { status: 201 });
+  }),
+
+  http.get(`/api/v1/shift-slots/${DUMMY_IDS.shiftSlotId1}`, () => {
+    return HttpResponse.json({ data: DUMMY_SHIFT_SLOTS[0] });
+  }),
+
+  // === メンバー ===
+  http.post('/api/v1/members', () => {
+    return HttpResponse.json({ data: DUMMY_MEMBERS[0] }, { status: 201 });
+  }),
+
+  http.get('/api/v1/members', ({ request }) => {
+    return mergeWithRealData(request, request.url, 'members', DUMMY_MEMBERS);
+  }),
+
+  // === 出欠確認 ===
+  http.post('/api/v1/attendance/collections', () => {
+    collectionStatus = 'open';
+    return HttpResponse.json({ data: DUMMY_COLLECTION }, { status: 201 });
+  }),
+
+  http.get('/api/v1/attendance/collections', ({ request }) => {
+    const currentCollection = { ...DUMMY_COLLECTION, status: collectionStatus };
+    return mergeWithRealData(request, request.url, 'collections', [currentCollection]);
+  }),
+
+  http.get('/api/v1/attendance/collections/:collectionId', ({ params }) => {
+    const { collectionId } = params;
+    if (typeof collectionId === 'string' && isTutorialId(collectionId)) {
+      return HttpResponse.json({
+        data: { ...DUMMY_COLLECTION, status: collectionStatus },
+      });
+    }
+    return passthrough();
+  }),
+
+  http.get('/api/v1/attendance/collections/:collectionId/responses', ({ params }) => {
+    const { collectionId } = params;
+    if (typeof collectionId === 'string' && isTutorialId(collectionId)) {
+      return HttpResponse.json({ data: { responses: DUMMY_RESPONSES } });
+    }
+    return passthrough();
+  }),
+
+  http.post('/api/v1/attendance/collections/:collectionId/close', ({ params }) => {
+    const { collectionId } = params;
+    if (typeof collectionId === 'string' && isTutorialId(collectionId)) {
+      collectionStatus = 'closed';
+      return HttpResponse.json({
+        data: { ...DUMMY_COLLECTION, status: 'closed' },
+      });
+    }
+    return passthrough();
+  }),
+
+  // === シフト割り当て ===
+  http.post('/api/v1/assignments/confirm', () => {
+    return HttpResponse.json({
+      data: { message: 'Assignments confirmed' },
+    });
+  }),
+
+  // === カレンダー ===
+  http.post('/api/v1/calendars', () => {
+    return HttpResponse.json({ data: DUMMY_CALENDAR }, { status: 201 });
+  }),
+
+  http.get('/api/v1/calendars', ({ request }) => {
+    return mergeWithRealData(request, request.url, 'calendars', [DUMMY_CALENDAR]);
+  }),
+
+  http.put(`/api/v1/calendars/${DUMMY_IDS.calendarId}`, () => {
+    return HttpResponse.json({ data: DUMMY_CALENDAR });
+  }),
+];

--- a/web-frontend/src/features/onboarding/onboarding.css
+++ b/web-frontend/src/features/onboarding/onboarding.css
@@ -1,0 +1,85 @@
+/* driver.js テーマカスタマイズ */
+.driver-popover {
+  --driver-theme-primary: #7B68EE;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  max-width: 380px;
+}
+
+.driver-popover .driver-popover-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.driver-popover .driver-popover-description {
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.driver-popover .driver-popover-progress-text {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.driver-popover-footer button {
+  border-radius: 8px;
+  font-size: 0.875rem;
+  padding: 8px 16px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+}
+
+.driver-popover-footer .driver-popover-next-btn {
+  background-color: #7B68EE;
+  color: white;
+  border: none;
+}
+
+.driver-popover-footer .driver-popover-next-btn:hover {
+  background-color: #5B48CE;
+}
+
+.driver-popover-footer .driver-popover-prev-btn {
+  background-color: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.driver-popover-footer .driver-popover-prev-btn:hover {
+  background-color: #e5e7eb;
+}
+
+/* ハイライト時のオーバーレイ */
+.driver-overlay {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+/* モバイル対応 */
+@media (max-width: 768px) {
+  .driver-popover {
+    max-width: calc(100vw - 32px);
+    margin: 8px;
+  }
+}
+
+/* チュートリアル完了画面 */
+.onboarding-complete {
+  text-align: center;
+  padding: 24px;
+}
+
+.onboarding-complete h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 12px;
+}
+
+.onboarding-complete p {
+  font-size: 0.875rem;
+  color: #6b7280;
+  line-height: 1.6;
+}

--- a/web-frontend/src/features/onboarding/steps/types.ts
+++ b/web-frontend/src/features/onboarding/steps/types.ts
@@ -1,0 +1,80 @@
+export type OnboardingPhase =
+  | 'idle'
+  | 'sidebar'
+  | 'role'
+  | 'event'
+  | 'template'
+  | 'businessDay'
+  | 'shiftSlot'
+  | 'member'
+  | 'attendance'
+  | 'attendanceResponse'
+  | 'attendanceDetail'
+  | 'shiftAdjustment'
+  | 'calendar'
+  | 'summary'
+  | 'complete';
+
+export const PHASE_ORDER: OnboardingPhase[] = [
+  'sidebar',
+  'role',
+  'event',
+  'template',
+  'businessDay',
+  'shiftSlot',
+  'member',
+  'attendance',
+  'attendanceResponse',
+  'attendanceDetail',
+  'shiftAdjustment',
+  'calendar',
+  'summary',
+  'complete',
+];
+
+export interface DummyIds {
+  roleId1: string;
+  roleId2: string;
+  eventId: string;
+  templateId: string;
+  businessDayId: string;
+  shiftSlotId1: string;
+  shiftSlotId2: string;
+  memberId1: string;
+  memberId2: string;
+  memberId3: string;
+  collectionId: string;
+  targetDateId1: string;
+  calendarId: string;
+}
+
+export const DUMMY_IDS: DummyIds = {
+  roleId1: 'tut_role_001',
+  roleId2: 'tut_role_002',
+  eventId: 'tut_event_001',
+  templateId: 'tut_template_001',
+  businessDayId: 'tut_bd_001',
+  shiftSlotId1: 'tut_slot_001',
+  shiftSlotId2: 'tut_slot_002',
+  memberId1: 'tut_member_001',
+  memberId2: 'tut_member_002',
+  memberId3: 'tut_member_003',
+  collectionId: 'tut_collection_001',
+  targetDateId1: 'tut_td_001',
+  calendarId: 'tut_calendar_001',
+};
+
+export interface OnboardingState {
+  isActive: boolean;
+  currentPhase: OnboardingPhase;
+  dummyIds: DummyIds;
+  mswReady: boolean;
+}
+
+export type OnboardingAction =
+  | { type: 'START' }
+  | { type: 'STOP' }
+  | { type: 'SET_PHASE'; phase: OnboardingPhase }
+  | { type: 'NEXT_PHASE' }
+  | { type: 'SET_MSW_READY'; ready: boolean }
+  | { type: 'RESTORE'; state: OnboardingState };

--- a/web-frontend/src/pages/AttendanceDetail.tsx
+++ b/web-frontend/src/pages/AttendanceDetail.tsx
@@ -473,6 +473,7 @@ export default function AttendanceDetail() {
             {getStatusBadge(collection.status)}
             {collection.status === 'open' && (
               <button
+                id="btn-close-collection"
                 onClick={handleClose}
                 disabled={closing}
                 className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition disabled:bg-gray-400 text-sm"
@@ -490,6 +491,7 @@ export default function AttendanceDetail() {
             {/* シフト調整ボタン: イベントに紐づけられた出欠確認が締め切られた場合のみ表示 */}
             {collection.status === 'closed' && collection.target_type === 'event' && collection.target_id && (
               <button
+                id="btn-shift-adjustment"
                 onClick={() => navigate(`/attendance/${collectionId}/shift-adjustment`)}
                 className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition text-sm"
               >

--- a/web-frontend/src/pages/AttendanceList.tsx
+++ b/web-frontend/src/pages/AttendanceList.tsx
@@ -477,6 +477,7 @@ export default function AttendanceList() {
               setShowCreateForm(true);
             }
           }}
+          id="btn-create-attendance"
           className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-dark transition-colors font-medium text-sm sm:text-base w-full sm:w-auto"
         >
           {showCreateForm ? (isEditing ? '編集をキャンセル' : 'キャンセル') : '+ 新規作成'}
@@ -873,6 +874,7 @@ export default function AttendanceList() {
             )}
 
             <button
+              id="btn-submit-attendance"
               type="submit"
               disabled={submitting || loadingEdit || !title.trim()}
               className="w-full px-4 py-2 bg-accent text-white rounded-md hover:bg-accent-dark transition disabled:bg-gray-400 disabled:cursor-not-allowed"

--- a/web-frontend/src/pages/BusinessDayList.tsx
+++ b/web-frontend/src/pages/BusinessDayList.tsx
@@ -164,6 +164,7 @@ export default function BusinessDayList() {
         </div>
         <div className="flex gap-2">
           <Link
+            id="link-template-management"
             to={`/events/${eventId}/templates`}
             className="bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-lg flex items-center"
           >
@@ -201,7 +202,7 @@ export default function BusinessDayList() {
             </svg>
             インスタンス
           </Link>
-          <button onClick={() => setShowCreateModal(true)} className="btn-primary">
+          <button id="btn-create-business-day" onClick={() => setShowCreateModal(true)} className="btn-primary">
             ＋ 営業日を追加
           </button>
         </div>

--- a/web-frontend/src/pages/CalendarList.tsx
+++ b/web-frontend/src/pages/CalendarList.tsx
@@ -154,7 +154,7 @@ export default function CalendarList() {
       <SEO noindex={true} />
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-6">
         <h2 className="text-xl sm:text-2xl font-bold text-gray-900">カレンダー一覧</h2>
-        <button onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
+        <button id="btn-create-calendar" onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
           ＋ 新しいカレンダー
         </button>
       </div>
@@ -497,6 +497,7 @@ function CalendarFormModal({
               キャンセル
             </button>
             <button
+              id="btn-submit-calendar"
               type="submit"
               className="flex-1 btn-primary"
               disabled={loading || !title.trim()}

--- a/web-frontend/src/pages/EventList.tsx
+++ b/web-frontend/src/pages/EventList.tsx
@@ -190,7 +190,7 @@ export default function EventList() {
       <SEO noindex={true} />
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-6">
         <h2 className="text-xl sm:text-2xl font-bold text-gray-900">イベント一覧</h2>
-        <button onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
+        <button id="btn-create-event" onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
           ＋ 新しいイベント
         </button>
       </div>
@@ -602,6 +602,7 @@ function CreateEventModal({
               キャンセル
             </button>
             <button
+              id="btn-submit-event"
               type="submit"
               className="flex-1 btn-primary"
               disabled={loading || !eventName.trim()}

--- a/web-frontend/src/pages/Members.tsx
+++ b/web-frontend/src/pages/Members.tsx
@@ -291,7 +291,7 @@ export default function Members() {
           <button onClick={() => setShowBulkImportModal(true)} className="btn-secondary text-xs sm:text-sm">
             一括登録
           </button>
-          <button onClick={handleOpenCreateForm} className="btn-primary text-xs sm:text-sm">
+          <button id="btn-create-member" onClick={handleOpenCreateForm} className="btn-primary text-xs sm:text-sm">
             ＋ 追加
           </button>
         </div>
@@ -709,6 +709,7 @@ function MemberFormModal({
               表示名 <span className="text-red-500">*</span>
             </label>
             <input
+              id="member-display-name"
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
@@ -772,7 +773,7 @@ function MemberFormModal({
             >
               キャンセル
             </button>
-            <button type="submit" className="flex-1 btn-primary" disabled={submitting}>
+            <button id="btn-submit-member" type="submit" className="flex-1 btn-primary" disabled={submitting}>
               {submitting ? '処理中...' : member ? '更新' : '登録'}
             </button>
           </div>

--- a/web-frontend/src/pages/RoleList.tsx
+++ b/web-frontend/src/pages/RoleList.tsx
@@ -76,7 +76,7 @@ export default function RoleList() {
           <h2 className="text-xl sm:text-2xl font-bold text-gray-900">ロール管理</h2>
           <p className="text-xs sm:text-sm text-gray-600 mt-1">メンバーに付与する役割・属性を管理します</p>
         </div>
-        <button onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
+        <button id="btn-create-role" onClick={() => setShowCreateModal(true)} className="btn-primary text-sm sm:text-base w-full sm:w-auto">
           ＋ ロール追加
         </button>
       </div>
@@ -382,6 +382,7 @@ function RoleFormModal({
               キャンセル
             </button>
             <button
+              id="btn-submit-role"
               type="submit"
               className="flex-1 btn-primary"
               disabled={loading || !name}

--- a/web-frontend/src/pages/ShiftAdjustment.tsx
+++ b/web-frontend/src/pages/ShiftAdjustment.tsx
@@ -449,7 +449,7 @@ export default function ShiftAdjustment() {
       </div>
 
       {/* 日付タブ */}
-      <div className="bg-white rounded-lg shadow mb-6">
+      <div id="shift-date-tabs" className="bg-white rounded-lg shadow mb-6">
         <div className="border-b border-gray-200">
           <nav className="flex overflow-x-auto -mb-px">
             {sortedDates.map((date) => {
@@ -488,7 +488,7 @@ export default function ShiftAdjustment() {
       {/* メインコンテンツ */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* 左: 参加者一覧 */}
-        <div className="bg-white rounded-lg shadow p-4">
+        <div id="shift-attending-members" className="bg-white rounded-lg shadow p-4">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">
             参加者
             <span className="ml-2 text-sm font-normal text-gray-500">
@@ -664,7 +664,7 @@ export default function ShiftAdjustment() {
         </div>
 
         {/* 右: シフト枠（インスタンスごとにグループ化） */}
-        <div className="lg:col-span-2">
+        <div id="shift-slot-assignments" className="lg:col-span-2">
           {slots.length === 0 ? (
             <div className="bg-white rounded-lg shadow p-6 text-center">
               <p className="text-gray-500 mb-4">この日のシフト枠がまだ作成されていません</p>

--- a/web-frontend/src/pages/TemplateForm.tsx
+++ b/web-frontend/src/pages/TemplateForm.tsx
@@ -376,6 +376,7 @@ export default function TemplateForm() {
               </p>
             </div>
             <button
+              id="btn-add-instance"
               type="button"
               onClick={addInstance}
               disabled={loading}
@@ -617,6 +618,7 @@ export default function TemplateForm() {
             キャンセル
           </button>
           <button
+            id="btn-submit-template"
             type="submit"
             disabled={loading || instanceGroups.length === 0}
             className="flex-1 bg-accent hover:bg-accent-dark text-white px-6 py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"

--- a/web-frontend/src/pages/TemplateList.tsx
+++ b/web-frontend/src/pages/TemplateList.tsx
@@ -105,6 +105,7 @@ const TemplateList = () => {
           </p>
         </div>
         <button
+          id="btn-create-template"
           onClick={() => navigate(`/events/${eventId}/templates/new`)}
           className="bg-accent hover:bg-accent-dark text-white px-4 py-2 rounded-lg flex items-center"
         >


### PR DESCRIPTION
## Summary
- driver.js + MSW を使った15ステップのインタラクティブオンボーディングツアーを実装
- ダミーデータで全機能（ロール→イベント→テンプレート→営業日→シフト枠→メンバー→出欠→シフト調整→カレンダー）を体験可能
- 実データには一切影響なし（MSWがAPIインターセプト、チュートリアル終了時に自動クリーンアップ）

## 技術構成
- **driver.js** (~5KB gzip): ステップガイド・ハイライト表示
- **MSW** (~12KB): Service WorkerレベルでAPI mock（19エンドポイント）
- **コード分割**: MSWチャンクを動的importで分離（244KB、メインバンドルに影響なし）
- **状態管理**: React Context + sessionStorage（リフレッシュ対応）

## 新規ファイル (8ファイル)
- `features/onboarding/OnboardingContext.tsx` - 状態管理
- `features/onboarding/OnboardingTour.tsx` - 15フェーズのメインオーケストレータ
- `features/onboarding/components/StartTutorialButton.tsx` - ヘッダー起動ボタン
- `features/onboarding/hooks/useOnboarding.ts` - カスタムフック
- `features/onboarding/mocks/handlers.ts` - MSWハンドラー（bypass使用）
- `features/onboarding/mocks/data.ts` - ダミーデータ
- `features/onboarding/mocks/browser.ts` - MSWワーカー設定
- `features/onboarding/steps/types.ts` - 型定義

## 既存ファイル変更 (14ファイル)
- `App.tsx`: OnboardingProvider ラッパー追加
- `Layout.tsx`: nav id属性 + StartTutorialButton + OnboardingTour
- 12ページコンポーネント: チュートリアル用id属性追加

## Test plan
- [ ] `npm run build` がパスすること
- [ ] ヘッダーの「体験ツアー」ボタンからチュートリアル開始
- [ ] 全15ステップを通しプレイ（サイドバー→ロール→イベント→テンプレート→営業日→シフト枠→メンバー→出欠→出欠回答説明→出欠詳細→シフト調整→カレンダー→まとめ→完了）
- [ ] チュートリアル中、実データが変更されていないことを確認（DevTools > Network）
- [ ] ページリフレッシュでチュートリアル状態が復帰すること
- [ ] ESCキーでチュートリアル中断 → 「中断」ボタンで停止できること
- [ ] チュートリアル終了後にダミーデータが消えること（ページリロード）
- [ ] 「もう一度見る」で再スタート可能なこと

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)